### PR TITLE
Twelve days - Date calculations

### DIFF
--- a/tests/twelve_days_of_christmas.k
+++ b/tests/twelve_days_of_christmas.k
@@ -16,7 +16,7 @@ class Person {
 
 class Ordinal {
     public Ordinal(int order) {
-System.out.println(order)
+        System.out.println(order)
         assert(order >= 1 && order <= 12, 
             "'rdinals only supp'rt'd from one to twelve");
 
@@ -100,13 +100,18 @@ context TwelveDaysOfChristmas {
 
     stageprop Christmas {
         public String dayOfTheSeason(Date date) {
+            // NOTE: Incorrect dates
+            System.out.print(date.getYear()); System.out.print("-");
+            System.out.print(date.getMonth()+1); System.out.print("-");
+            System.out.println(date.getDate());
+
             // NOTE: Date::getTime could be useful here
             // https://docs.oracle.com/javase/7/docs/api/java/util/Date.html#getTime()
             int startDate = this.getDate();
-
-            // NOTE: It seems like this expression doesn't work
-            // Need to parenthesize the "if" expression for proper precedence
             int currentDate = date.getDate() + (if(date.getDate() < startDate)  31 else 0);
+
+            System.out.println(startDate);
+            System.out.println(currentDate);
 
             return new Ordinal(currentDate - startDate + 1).name();
         }

--- a/tests/twelve_days_of_christmas.k
+++ b/tests/twelve_days_of_christmas.k
@@ -132,7 +132,7 @@ context TwelveDaysOfChristmas {
         Giver = giver;
         Gifts = gifts;
         Receiver = receiver;
-        Christmas = new Date(2015, 12, 25);
+        Christmas = new Date(2015, 11, 25);
         Singers = System.out;
     }
 


### PR DESCRIPTION
I wasn't specific in #22, the runtime error happens because the Date calculations seems incorrect. I'm doing `new Date(2015,11,25)` and gets back `1932-06-06` according to this PR.
