### PR TITLE
Fix Panel flickering

### DIFF
--- a/examples/borrow_library_panel1.k
+++ b/examples/borrow_library_panel1.k
@@ -14,7 +14,7 @@ class MyPanel extends Panel {
       frame_.resize(600, 400);
       text_ = new List<ALine>();
       repaint();
-      setForeground(Color.blue);
+      setColor(Color.blue);
       reframe()
    }
    private void reframe() {
@@ -44,7 +44,7 @@ class MyPanel extends Panel {
    }
 */
    public void print(String text) {
-      text_.add(new ALine(text.clone, this.getForeground()));
+      text_.add(new ALine(text.clone, this.getColor()));
       redisplayTextBuffer()
    }
    public void println(String text) {
@@ -63,7 +63,7 @@ class MyPanel extends Panel {
    public void redisplayTextBuffer() {
       int y = 100, x = 25;
       int numberOfLinesInFrame = 9, currentLine = 1;
-      removeAll(); //repaint();
+      clear();
       fillRect(20, 85, 550, 150);
       drawRect(20, 85, 550, 150);
 
@@ -74,7 +74,7 @@ class MyPanel extends Panel {
                x = 25;
                y = y + 14
             } else {
-               this.setForeground(aLine.color());
+               this.setColor(aLine.color());
                this.drawString(x, y, aLine.text());
 System.err.print("last output to screen: ").println(aLine.text())
                x = x + width(aLine.text())
@@ -83,14 +83,14 @@ System.err.print("last output to screen: ").println(aLine.text())
             currentLine++;
          }
       }
-      this.setForeground(Color.blue);
+      this.setColor(Color.blue);
       repaint();
       frame_.setVisible(true);
    }
    public void flush() {
       redisplayTextBuffer()
    }
- 
+
    private List<ALine> text_;
    private Frame frame_
 }
@@ -106,13 +106,13 @@ System.err.print("last output to screen: ").println(aLine.text())
       Frame frame = new Frame("First Frame");
       frame.add("Center", panel);
       frame.resize(300, 300);
-      panel.setForeground(Color.black);
+      panel.setColor(Color.black);
       panel.drawString(120, 120, "Hello world");
-      panel.setForeground(Color.green);
+      panel.setColor(Color.green);
       panel.drawLine(120, 122, 190, 122);
-      panel.setForeground(Color.blue);
+      panel.setColor(Color.blue);
       panel.drawRect(20, 20, 70, 100);
-      panel.setForeground(Color.red);
+      panel.setColor(Color.red);
       panel.drawOval(45, 100, 80, 80);
       frame.setVisible(true)
    }
@@ -124,8 +124,8 @@ interface ItemRecord {
 }
 
 class Book implements ItemRecord {
-    public Book(String name) { 
-        name_ = name.clone; 
+    public Book(String name) {
+        name_ = name.clone;
         id_ = Math.random();
     }
 
@@ -160,7 +160,7 @@ class MockBookScanner {
     }
 
     public List<ItemRecord> scannedItems() { return scannedItems_ }
-    
+
     List<ItemRecord> scannedItems_;
     List<ItemRecord> books_;
 }
@@ -211,7 +211,7 @@ context BorrowLibraryItems {
                 Screen.displayScannedItems();
             }
         }
-    
+
         public List<ItemRecord> currentScannedItems() {
             return scannedItems()
         }
@@ -228,16 +228,16 @@ context BorrowLibraryItems {
         public void displayScannedItems() {
             println("Borrowed items:");
             for(ItemRecord item : BookScanner.currentScannedItems()) {
-                setForeground(Color.magenta);
+                setColor(Color.magenta);
                 println(item.name());
-                setForeground(Color.blue);
+                setColor(Color.blue);
             }
             selectOptions();
         }
         public void displayItemAlreadyScanned(ItemRecord item) {
-            setForeground(Color.red);
+            setColor(Color.red);
             println("Item '"+item.name()+"' has already been scanned.");
-            setForeground(Color.blue);
+            setColor(Color.blue);
             selectOptions();
         }
         public void displayEnterPin() {
@@ -248,19 +248,19 @@ context BorrowLibraryItems {
            print(text);
         }
         public void displayInvalidPinAttempts() {
-            setForeground(Color.red);
+            setColor(Color.red);
             println("Three invalid attempts, please remove your card.")
-            setForeground(Color.blue);
+            setColor(Color.blue);
         }
         public void displayInvalidPin() {
-            setForeground(Color.red);
+            setColor(Color.red);
             println("Invalid PIN code.")
-            setForeground(Color.blue);
+            setColor(Color.blue);
         }
         public void echoInvisibleChar() {
-            setForeground(new Color(52, 200, 5));
+            setColor(new Color(52, 200, 5));
             print("*")
-            setForeground(Color.blue);
+            setColor(Color.blue);
         }
         public void closeLine() {
             println("")
@@ -283,7 +283,7 @@ context BorrowLibraryItems {
             print("Select option: ");
 
             String choice = Keypad.readChar();
-            Screen.setForeground(new Color(52, 200, 5));
+            Screen.setColor(new Color(52, 200, 5));
             Screen.println(choice);
             switch(choice) {
                 case "2":
@@ -307,12 +307,12 @@ context BorrowLibraryItems {
         void println(String text) const;
         void flush();
         void repaint();
-        void removeAll();
+        void clear();
         void redisplayTextBuffer();
-        void setForeground(Color color);
-        Color getForeground()	// temporary
+        void setColor(Color color);
+        Color getColor()	// temporary
     }
-    
+
     stageprop Printer {
         public void printReceiptOfScannedItems() {
             cutPaper();

--- a/examples/borrow_library_panel1.k
+++ b/examples/borrow_library_panel1.k
@@ -64,7 +64,6 @@ class MyPanel extends Panel {
       int y = 100, x = 25;
       int numberOfLinesInFrame = 9, currentLine = 1;
       clear();
-      fillRect(20, 85, 550, 150);
       drawRect(20, 85, 550, 150);
 
       int numberOfLinesInText = numberOfLinesIn(text_);
@@ -303,8 +302,8 @@ context BorrowLibraryItems {
         }
         public void update() { redisplayTextBuffer(); }
     } requires {
-        void print(String text) const;
-        void println(String text) const;
+        void print(String text);
+        void println(String text);
         void flush();
         void repaint();
         void clear();

--- a/examples/borrow_library_panel1.k
+++ b/examples/borrow_library_panel1.k
@@ -19,6 +19,11 @@ class MyPanel extends Panel {
    }
    private void reframe() {
       // Text outline
+      Color saveColor = panel_.getColor();
+      panel_.setColor(Color.white)
+      panel_.fillRect(20, 85, 550, 150)
+      panel_.setColor(saveColor)
+
       drawRect(20, 85, 550, 150);
    }
 

--- a/examples/borrow_library_panel2.k
+++ b/examples/borrow_library_panel2.k
@@ -75,6 +75,12 @@ class TextListView implements View {
    public void removeAll() { items_ = new List<String>() }
    public void addItem(String item) { items_.add(item) }
    private void reframe() {
+      Color saveColor = panel_.getColor();
+      panel_.setColor(Color.white)
+      panel_.fillRect(xOffset_, yOffset_ + TitleHeight,
+                      FrameWidth, FrameHeight)
+      panel_.setColor(saveColor)
+
       // Text outline
       panel_.drawString(xOffset_, yOffset_ + LineHeight, title_);
       panel_.drawRect(xOffset_, yOffset_ + TitleHeight,
@@ -105,6 +111,11 @@ class TextLogView implements View {
       reframe()
    }
    private void reframe() {
+      Color saveColor = panel_.getColor();
+      panel_.setColor(Color.white)
+      panel_.fillRect(xOffset_, yOffset_, FrameWidth, FrameHeight)
+      panel_.setColor(saveColor)
+
       // Text outline
       panel_.drawRect(xOffset_, yOffset_, FrameWidth, FrameHeight)
    }
@@ -132,7 +143,6 @@ class TextLogView implements View {
    public void notifyChanged() {
       int y = yOffset_ + TopMargin, x = xOffset_ + TextIndent;
       int currentLine = 1;
-      panel_.clear();
       reframe();
 
       int numberOfLinesInText = numberOfLinesIn(text_);

--- a/examples/borrow_library_panel2.k
+++ b/examples/borrow_library_panel2.k
@@ -5,9 +5,9 @@ class MyPanel extends Panel {
       frame_.add("Center", this);
       frame_.resize(600, 400);
       repaint();
-      setForeground(Color.blue);
+      setColor(Color.blue);
    }
-  
+
 
 /*
    public void handleEvent(Event event) {
@@ -33,7 +33,7 @@ class MyPanel extends Panel {
    public Frame frame() {
       return frame_
    }
- 
+
    private Frame frame_
 }
 
@@ -65,12 +65,12 @@ class TextListView implements View {
       int listCounter = 1;
       for (String item : items_) {
          String toPrint = listCounter.toString() + ". " + item;
-         panel_.setForeground(Color.black);
+         panel_.setColor(Color.black);
          panel_.drawString(x, y, toPrint);
          y = y + LineHeight;
          listCounter++
       }
-      panel_.setForeground(Color.blue);
+      panel_.setColor(Color.blue);
    }
    public void removeAll() { items_ = new List<String>() }
    public void addItem(String item) { items_.add(item) }
@@ -100,7 +100,6 @@ class TextLogView implements View {
 
    public TextLogView(MyPanel panel, int xOffset, int yOffset) {
       text_ = new List<ALine>();
-      dynamicStringCookies_ = new List<Object>();
       panel_ = panel;
       frame_ = panel.frame();
       xOffset_ = xOffset.clone;
@@ -124,7 +123,7 @@ class TextLogView implements View {
    }
 
    public void print(String text) {
-      text_.add(new ALine(text.clone, panel_.getForeground()));
+      text_.add(new ALine(text.clone, panel_.getColor()));
       this.notifyChanged()
    }
    public void println(String text) {
@@ -137,11 +136,7 @@ class TextLogView implements View {
    public void notifyChanged() {
       int y = yOffset_ + TopMargin, x = xOffset_ + TextIndent;
       int currentLine = 1;
-      //panel_.removeAll();
-      for (Object a : dynamicStringCookies_) {
-         panel_.remove(a);
-      }
-      dynamicStringCookies_ = new List<Object>();
+      panel_.clear();
       reframe();
 
       int numberOfLinesInText = numberOfLinesIn(text_);
@@ -151,16 +146,15 @@ class TextLogView implements View {
                x = xOffset_ + TextIndent;
                y = y + LineHeight
             } else {
-               panel_.setForeground(aLine.color());
-               Object cookie = panel_.drawString(x, y, aLine.text());
-               dynamicStringCookies_.add(cookie)
+               panel_.setColor(aLine.color());
+               panel_.drawString(x, y, aLine.text());
                x = x + widthOf(aLine.text())
             }
          } else if (aLine.text() == "\n") {
             currentLine++;
          }
       }
-      panel_.setForeground(Color.blue);
+      panel_.setColor(Color.blue);
       panel_.repaint();
       frame_.setVisible(true)
    }
@@ -170,13 +164,12 @@ class TextLogView implements View {
          if (aLine.text() == "\n") retval++;
       return retval
    }
-   
+
    public void flush() {
       this.notifyChanged()
    }
 
    private List<ALine> text_;
-   private List<Object> dynamicStringCookies_;
    private MyPanel panel_
    private Frame frame_;
    private int xOffset_, yOffset_
@@ -188,8 +181,8 @@ interface ItemRecord {
 }
 
 class Book implements ItemRecord {
-    public Book(String name) { 
-        name_ = name.clone; 
+    public Book(String name) {
+        name_ = name.clone;
         id_ = Math.random();
     }
 
@@ -224,7 +217,7 @@ class MockBookScanner {
     }
 
     public List<ItemRecord> scannedItems() { return scannedItems_ }
-    
+
     List<ItemRecord> scannedItems_;
     List<ItemRecord> books_;
 }
@@ -275,7 +268,7 @@ context BorrowLibraryItems {
                 Accountant.displayScannedItems();
             }
         }
-    
+
         public List<ItemRecord> currentScannedItems() {
             return scannedItems()
         }
@@ -285,10 +278,10 @@ context BorrowLibraryItems {
     }
 
     role ColorHandler {
-       public void setForegroundColor(Color c) { setForeground(c) }
+       public void setForegroundColor(Color c) { setColor(c) }
        public Color inputColor() { return new Color(50, 200, 5) }
     } requires {
-       void setForeground(Color c)
+       void setColor(Color c)
     }
 
     role TranscriptView {
@@ -371,7 +364,7 @@ context BorrowLibraryItems {
             Menu.selectOptions();
         }
     }
-    
+
     stageprop Printer {
         public void printReceiptOfScannedItems() {
             cutPaper();

--- a/examples/borrow_library_panel2.k
+++ b/examples/borrow_library_panel2.k
@@ -77,8 +77,6 @@ class TextListView implements View {
    private void reframe() {
       // Text outline
       panel_.drawString(xOffset_, yOffset_ + LineHeight, title_);
-      panel_.fillRect(xOffset_, yOffset_ + TitleHeight,
-                      FrameWidth, FrameHeight);
       panel_.drawRect(xOffset_, yOffset_ + TitleHeight,
                       FrameWidth, FrameHeight);
    }
@@ -108,8 +106,6 @@ class TextLogView implements View {
    }
    private void reframe() {
       // Text outline
-      panel_.fillRect(xOffset_, yOffset_, FrameWidth, FrameHeight);
-      panel_.drawRect(xOffset_, yOffset_, FrameWidth, FrameHeight);
       panel_.drawRect(xOffset_, yOffset_, FrameWidth, FrameHeight)
    }
 
@@ -305,8 +301,8 @@ context BorrowLibraryItems {
         public void closeLine() { println("") }
         public void changed() { notifyChanged();/* CheckoutList.changed() */}
     } requires {
-        void print(String text) const;
-        void println(String text) const;
+        void print(String text);
+        void println(String text);
         void notifyChanged()
     }
 

--- a/examples/borrow_library_panel3.k
+++ b/examples/borrow_library_panel3.k
@@ -118,8 +118,6 @@ class TextListView implements View {
    public void addItem(String item) { items_.add(item) }
    private void reframe() {
       // Text outline
-      panel_.fillRect(xOffset_, yOffset_ + TitleHeight,
-                      FrameWidth, FrameHeight);
       panel_.drawRect(xOffset_, yOffset_ + TitleHeight,
                       FrameWidth, FrameHeight)
    }
@@ -149,8 +147,6 @@ class TextLogView implements View {
    }
    private void reframe() {
       // Text outline
-      panel_.fillRect(xOffset_, yOffset_, FrameWidth, FrameHeight);
-      panel_.drawRect(xOffset_, yOffset_, FrameWidth, FrameHeight);
       panel_.drawRect(xOffset_, yOffset_, FrameWidth, FrameHeight)
    }
 
@@ -357,8 +353,8 @@ context BorrowLibraryItems implements ButtonHandler {
         public void closeLine() { println("") }
         public void changed() { notifyChanged();/* CheckoutList.changed() */}
     } requires {
-        void print(String text) const;
-        void println(String text) const;
+        void print(String text);
+        void println(String text);
         void notifyChanged()
     }
 

--- a/examples/borrow_library_panel3.k
+++ b/examples/borrow_library_panel3.k
@@ -118,6 +118,12 @@ class TextListView implements View {
    public void addItem(String item) { items_.add(item) }
    private void reframe() {
       // Text outline
+      Color saveColor = panel_.getColor();
+      panel_.setColor(Color.white)
+      panel_.fillRect(xOffset_, yOffset_ + TitleHeight,
+                      FrameWidth, FrameHeight)
+      panel_.setColor(saveColor)
+
       panel_.drawRect(xOffset_, yOffset_ + TitleHeight,
                       FrameWidth, FrameHeight)
    }
@@ -146,6 +152,11 @@ class TextLogView implements View {
       reframe()
    }
    private void reframe() {
+      Color saveColor = panel_.getColor();
+      panel_.setColor(Color.white)
+      panel_.fillRect(xOffset_, yOffset_, FrameWidth, FrameHeight)
+      panel_.setColor(saveColor)
+
       // Text outline
       panel_.drawRect(xOffset_, yOffset_, FrameWidth, FrameHeight)
    }
@@ -173,7 +184,6 @@ class TextLogView implements View {
    public void notifyChanged() {
       int y = yOffset_ + TopMargin, x = xOffset_ + TextIndent;
       int currentLine = 1;
-      panel_.clear();
       reframe();
 
       int numberOfLinesInText = numberOfLinesIn(text_);

--- a/examples/borrow_library_panel3.k
+++ b/examples/borrow_library_panel3.k
@@ -5,10 +5,10 @@ class MyPanel extends Panel {
       frame_.add("Center", this);
       frame_.resize(600, 400);
       repaint();
-      setForeground(Color.blue);
+      setColor(Color.blue);
       buttons_ = new List<Button>()
    }
-  
+
    public void addButton(Button button) { buttons_.add(button) }
 
    public boolean handleEvent(Event event) {
@@ -29,7 +29,7 @@ class MyPanel extends Panel {
    public Frame frame() {
       return frame_
    }
- 
+
    private List<Button> buttons_;
    private Frame frame_
 }
@@ -51,7 +51,7 @@ class Button {
    }
 
    public void wasPushed() { handler_.buttonWasPushed(this) }
- 
+
    public boolean contains(int x, int y) {
       int centerX = x_ + radius_;
       int centerY = y_ + radius_;
@@ -94,7 +94,6 @@ class TextListView implements View {
       yOffset_ = yOffset.clone;
       frame_ = panel.frame();
       title_ = title.clone;
-      clearList_ = new List<Object>();
       reframe()
    }
    public void notifyChanged() {
@@ -104,20 +103,15 @@ class TextListView implements View {
       int listCounter = 1;
       for (String item : items_) {
          String toPrint = listCounter.toString() + ". " + item;
-         panel_.setForeground(Color.black);
-         Object cookie = panel_.drawString(x, y, toPrint);
-         clearList_.add(cookie);
+         panel_.setColor(Color.black);
+         panel_.drawString(x, y, toPrint);
          y = y + LineHeight;
          listCounter++
       }
-      panel_.setForeground(Color.blue);
+      panel_.setColor(Color.blue);
    }
    public void removeAll() {
       items_ = new List<String>();
-      for (Object o : clearList_) {
-         panel_.remove(o)
-      }
-      clearList_ = new List<Object>();
       this.notifyChanged();
       this.reframe()
    }
@@ -131,7 +125,6 @@ class TextListView implements View {
    }
 
    private List<String> items_;
-   private List<Object> clearList_
    private MyPanel panel_;
    private int xOffset_, yOffset_;
    private Frame frame_;
@@ -148,7 +141,6 @@ class TextLogView implements View {
 
    public TextLogView(MyPanel panel, int xOffset, int yOffset) {
       text_ = new List<ALine>();
-      dynamicStringCookies_ = new List<Object>();
       panel_ = panel;
       frame_ = panel.frame();
       xOffset_ = xOffset.clone;
@@ -172,7 +164,7 @@ class TextLogView implements View {
    }
 
    public void print(String text) {
-      text_.add(new ALine(text.clone, panel_.getForeground()));
+      text_.add(new ALine(text.clone, panel_.getColor()));
       this.notifyChanged()
    }
    public void println(String text) {
@@ -185,10 +177,7 @@ class TextLogView implements View {
    public void notifyChanged() {
       int y = yOffset_ + TopMargin, x = xOffset_ + TextIndent;
       int currentLine = 1;
-      for (Object a : dynamicStringCookies_) {
-         panel_.remove(a);
-      }
-      dynamicStringCookies_ = new List<Object>();
+      panel_.clear();
       reframe();
 
       int numberOfLinesInText = numberOfLinesIn(text_);
@@ -198,16 +187,15 @@ class TextLogView implements View {
                x = xOffset_ + TextIndent;
                y = y + LineHeight
             } else {
-               panel_.setForeground(aLine.color());
-               Object cookie = panel_.drawString(x, y, aLine.text());
-               dynamicStringCookies_.add(cookie)
+               panel_.setColor(aLine.color());
+               panel_.drawString(x, y, aLine.text());
                x = x + widthOf(aLine.text())
             }
          } else if (aLine.text() == "\n") {
             currentLine++;
          }
       }
-      panel_.setForeground(Color.blue);
+      panel_.setColor(Color.blue);
       panel_.repaint();
       frame_.setVisible(true)
    }
@@ -223,7 +211,6 @@ class TextLogView implements View {
    }
 
    private List<ALine> text_;
-   private List<Object> dynamicStringCookies_;
    private MyPanel panel_
    private Frame frame_;
    private int xOffset_, yOffset_
@@ -235,8 +222,8 @@ interface ItemRecord {
 }
 
 class Book implements ItemRecord {
-    public Book(String name) { 
-        name_ = name.clone; 
+    public Book(String name) {
+        name_ = name.clone;
         id_ = Math.random()
     }
 
@@ -271,7 +258,7 @@ class MockBookScanner {
     }
 
     public List<ItemRecord> scannedItems() { return scannedItems_ }
-    
+
     public void removeItem(ItemRecord item) { scannedItems_.remove(item) }
 
     List<ItemRecord> scannedItems_;
@@ -330,7 +317,7 @@ context BorrowLibraryItems implements ButtonHandler {
            int theIndex = items.size() - 1;
            while (theIndex >= 0) { removeItem(items.get(theIndex--)) }
         }
-    
+
         public List<ItemRecord> currentScannedItems() {
             return scannedItems()
         }
@@ -343,10 +330,10 @@ context BorrowLibraryItems implements ButtonHandler {
     }
 
     role ColorHandler {
-       public void setForegroundColor(Color c) { setForeground(c) }
+       public void setForegroundColor(Color c) { setColor(c) }
        public Color inputColor() { return new Color(50, 200, 5) }
     } requires {
-       void setForeground(Color c)
+       void setColor(Color c)
     }
 
     role TranscriptView {
@@ -429,7 +416,7 @@ context BorrowLibraryItems implements ButtonHandler {
             Menu.selectOptions();
         }
     }
-    
+
     stageprop Printer {
         public void printReceiptOfScannedItems() {
             cutPaper();

--- a/examples/borrow_library_panel4.k
+++ b/examples/borrow_library_panel4.k
@@ -5,10 +5,10 @@ class MyPanel extends Panel {
       frame_.add("Center", this);
       frame_.resize(600, 400);
       repaint();
-      setForeground(Color.blue);
+      setColor(Color.blue);
       buttons_ = new List<Button>()
    }
-  
+
    public void addButton(Button button) { buttons_.add(button) }
 
    public boolean handleEvent(Event event) {
@@ -37,7 +37,7 @@ class MyPanel extends Panel {
    }
 
    public Frame frame() { return frame_ }
- 
+
    private List<Button> buttons_;
    private Frame frame_
 }
@@ -67,7 +67,7 @@ class Button {
       // In case of a drag that started inside a button
       state_="up"; draw()
    }
- 
+
    public boolean contains(int x, int y) {
       int centerX = x_ + radius_;
       int centerY = y_ + radius_;
@@ -80,16 +80,16 @@ class Button {
       panel_.drawOval(x_, y_, radius_, radius_);
       panel_.drawString(x_ + radius_ - ((label_.length() * 6) / 2),
                         y_+ radius_ + 6 , label_)
-      Color saveColor = panel_.getForeground();
+      Color saveColor = panel_.getColor();
       if (state_ == "down") {
-         panel_.setForeground(Color.blue);
+         panel_.setColor(Color.blue);
          panel_.fillOval(x_, y_, radius_, radius_)
       } else {
-         panel_.setForeground(new Color(0, 255, 255));
+         panel_.setColor(new Color(0, 255, 255));
          panel_.fillOval(x_+2, y_+1, radius_-2, radius_-1);
          panel_.drawOval(x_, y_, radius_, radius_)
       }
-      panel_.setForeground(saveColor)
+      panel_.setColor(saveColor)
    }
 
    public int x() { return x_ }
@@ -121,7 +121,6 @@ class TextListView implements View {
       yOffset_ = yOffset.clone;
       frame_ = panel.frame();
       title_ = title.clone;
-      clearList_ = new List<Object>();
       reframe()
    }
    public void notifyChanged() {
@@ -131,20 +130,15 @@ class TextListView implements View {
       int listCounter = 1;
       for (String item : items_) {
          String toPrint = listCounter.toString() + ". " + item;
-         panel_.setForeground(Color.black);
-         Object cookie = panel_.drawString(x, y, toPrint);
-         clearList_.add(cookie);
+         panel_.setColor(Color.black);
+         panel_.drawString(x, y, toPrint);
          y = y + LineHeight;
          listCounter++
       }
-      panel_.setForeground(Color.blue);
+      panel_.setColor(Color.blue);
    }
    public void removeAll() {
       items_ = new List<String>();
-      for (Object o : clearList_) {
-         panel_.remove(o)
-      }
-      clearList_ = new List<Object>();
       this.notifyChanged();
       this.reframe()
    }
@@ -158,7 +152,6 @@ class TextListView implements View {
    }
 
    private List<String> items_;
-   private List<Object> clearList_
    private MyPanel panel_;
    private int xOffset_, yOffset_;
    private Frame frame_;
@@ -175,7 +168,6 @@ class TextLogView implements View {
 
    public TextLogView(MyPanel panel, int xOffset, int yOffset) {
       text_ = new List<ALine>();
-      dynamicStringCookies_ = new List<Object>();
       panel_ = panel;
       frame_ = panel.frame();
       xOffset_ = xOffset.clone;
@@ -199,7 +191,7 @@ class TextLogView implements View {
    }
 
    public void print(String text) {
-      text_.add(new ALine(text.clone, panel_.getForeground()));
+      text_.add(new ALine(text.clone, panel_.getColor()));
       this.notifyChanged()
    }
    public void println(String text) {
@@ -210,8 +202,7 @@ class TextLogView implements View {
    public void notifyChanged() {
       int y = yOffset_ + TopMargin, x = xOffset_ + TextIndent;
       int currentLine = 1;
-      for (Object a : dynamicStringCookies_) panel_.remove(a);
-      dynamicStringCookies_ = new List<Object>();
+      panel_.clear();
       reframe();
 
       int numberOfLinesInText = numberOfLinesIn(text_);
@@ -221,16 +212,15 @@ class TextLogView implements View {
                x = xOffset_ + TextIndent;
                y = y + LineHeight
             } else {
-               panel_.setForeground(aLine.color());
-               Object cookie = panel_.drawString(x, y, aLine.text());
-               dynamicStringCookies_.add(cookie)
+               panel_.setColor(aLine.color());
+               panel_.drawString(x, y, aLine.text());
                x = x + widthOf(aLine.text())
             }
          } else if (aLine.text() == "\n") {
             currentLine++;
          }
       }
-      panel_.setForeground(Color.blue);
+      panel_.setColor(Color.blue);
       panel_.repaint();
       frame_.setVisible(true)
    }
@@ -246,7 +236,6 @@ class TextLogView implements View {
    }
 
    private List<ALine> text_;
-   private List<Object> dynamicStringCookies_;
    private MyPanel panel_
    private Frame frame_;
    private int xOffset_, yOffset_
@@ -258,8 +247,8 @@ interface ItemRecord {
 }
 
 class Book implements ItemRecord {
-    public Book(String name) { 
-        name_ = name.clone; 
+    public Book(String name) {
+        name_ = name.clone;
         id_ = Math.random()
     }
 
@@ -294,7 +283,7 @@ class MockBookScanner {
     }
 
     public List<ItemRecord> scannedItems() { return scannedItems_ }
-    
+
     public void removeItem(ItemRecord item) { scannedItems_.remove(item) }
 
     List<ItemRecord> scannedItems_;
@@ -353,7 +342,7 @@ context BorrowLibraryItems implements ButtonHandler {
            int theIndex = items.size() - 1;
            while (theIndex >= 0) { removeItem(items.get(theIndex--)) }
         }
-    
+
         public List<ItemRecord> currentScannedItems() { return scannedItems() }
 
         public int numberOfScannedItems() { return scannedItems().size() }
@@ -364,10 +353,10 @@ context BorrowLibraryItems implements ButtonHandler {
     }
 
     role ColorHandler {
-       public void setForegroundColor(Color c) { setForeground(c) }
+       public void setForegroundColor(Color c) { setColor(c) }
        public Color inputColor() { return new Color(50, 200, 5) }
     } requires {
-       void setForeground(Color c)
+       void setColor(Color c)
     }
 
     role TranscriptView {
@@ -446,7 +435,7 @@ context BorrowLibraryItems implements ButtonHandler {
             Menu.selectOptions();
         }
     }
-    
+
     stageprop Printer {
         public void printReceiptOfScannedItems() {
             cutPaper();

--- a/examples/borrow_library_panel4.k
+++ b/examples/borrow_library_panel4.k
@@ -145,8 +145,6 @@ class TextListView implements View {
    public void addItem(String item) { items_.add(item) }
    private void reframe() {
       // Text outline
-      panel_.fillRect(xOffset_, yOffset_ + TitleHeight,
-                      FrameWidth, FrameHeight);
       panel_.drawRect(xOffset_, yOffset_ + TitleHeight,
                       FrameWidth, FrameHeight)
    }
@@ -176,9 +174,7 @@ class TextLogView implements View {
    }
    private void reframe() {
       // Text outline
-      panel_.fillRect(xOffset_, yOffset_, FrameWidth, FrameHeight);
       panel_.drawRect(xOffset_, yOffset_, FrameWidth, FrameHeight);
-      panel_.drawRect(xOffset_, yOffset_, FrameWidth, FrameHeight)
    }
 
    class ALine {
@@ -380,8 +376,8 @@ context BorrowLibraryItems implements ButtonHandler {
         public void closeLine() { println("") }
         public void changed() { notifyChanged() }
     } requires {
-        void print(String text) const;
-        void println(String text) const;
+        void print(String text);
+        void println(String text);
         void notifyChanged()
     }
 

--- a/examples/borrow_library_panel4.k
+++ b/examples/borrow_library_panel4.k
@@ -77,10 +77,12 @@ class Button {
    }
 
    public void draw() {
+      Color saveColor = panel_.getColor();
+      panel_.setColor(Color.black);
       panel_.drawOval(x_, y_, radius_, radius_);
       panel_.drawString(x_ + radius_ - ((label_.length() * 6) / 2),
                         y_+ radius_ + 6 , label_)
-      Color saveColor = panel_.getColor();
+
       if (state_ == "down") {
          panel_.setColor(Color.blue);
          panel_.fillOval(x_, y_, radius_, radius_)
@@ -145,6 +147,11 @@ class TextListView implements View {
    public void addItem(String item) { items_.add(item) }
    private void reframe() {
       // Text outline
+      Color saveColor = panel_.getColor();
+      panel_.setColor(Color.white)
+      panel_.fillRect(xOffset_, yOffset_ + TitleHeight,
+                      FrameWidth, FrameHeight)
+      panel_.setColor(saveColor)
       panel_.drawRect(xOffset_, yOffset_ + TitleHeight,
                       FrameWidth, FrameHeight)
    }
@@ -173,6 +180,10 @@ class TextLogView implements View {
       reframe()
    }
    private void reframe() {
+      Color saveColor = panel_.getColor();
+      panel_.setColor(Color.white)
+      panel_.fillRect(xOffset_, yOffset_, FrameWidth, FrameHeight)
+      panel_.setColor(saveColor)
       // Text outline
       panel_.drawRect(xOffset_, yOffset_, FrameWidth, FrameHeight);
    }
@@ -198,7 +209,6 @@ class TextLogView implements View {
    public void notifyChanged() {
       int y = yOffset_ + TopMargin, x = xOffset_ + TextIndent;
       int currentLine = 1;
-      panel_.clear();
       reframe();
 
       int numberOfLinesInText = numberOfLinesIn(text_);

--- a/examples/borrow_library_panel5.k
+++ b/examples/borrow_library_panel5.k
@@ -1,0 +1,630 @@
+/* UI Library */
+
+class Rect {
+	public int x, y;
+	public int w, h;
+
+	public Rect(int ax, int ay, int aw, int ah){
+		x = ax.clone; y = ay.clone; w = aw.clone; h = ah.clone;
+	}
+
+	public int cx(){ return x + w / 2; }
+	public int cy(){ return y + h / 2; }
+
+	public boolean contains(Point p){
+		return (x <= p.x) && (p.x < x + w) && (y <= p.y) && (p.y < y + h);
+	}
+}
+
+interface Control {
+	public void    paint(Display display);
+	public boolean handleEvent(Event event);
+}
+
+class Display extends Panel {
+	public Display(Point size) {
+		Panel();
+
+		frame_  = new Frame("Book Checkout");
+		frame_.add("Center", this);
+		frame_.resize(size.x + 20, size.y + 40);
+		frame_.setVisible(true);
+
+		controls_ = new List<Control>();
+	}
+
+	public void invalidate(){
+		clear();
+		for(Control control: controls_){
+			control.paint(this);
+		}
+		repaint();
+	}
+
+	public boolean handleEvent(Event event){
+		boolean handled = false;
+		for(Control control: controls_){
+			if(control.handleEvent(event)){
+				handled = true;
+			}
+		}
+		if(handled){
+			invalidate();
+		}
+		return handled;
+	}
+
+	public void add(Control control)    { controls_.add(control);    }
+	public void remove(Control control) { controls_.remove(control); }
+
+	private Frame frame_;
+	private List<Control> controls_;
+}
+
+class Buttons implements Control {
+	public Buttons() {
+		list_ = new List<Button>();
+	}
+
+	public void paint(Display display){
+		for(Button button: list_){
+			button.paint(display);
+		}
+	}
+
+	public boolean handleEvent(Event event){
+		boolean handled = false;
+		for(Button button: list_){
+			if(button.handleEvent(event)){
+				handled = true;
+			}
+		}
+		return handled;
+	}
+
+	private List<Button> list_;
+
+	public void add(Button button)    { list_.add(button);    }
+	public void remove(Button button) { list_.remove(button); }
+}
+
+interface ButtonHandler {
+	 public void handleButtonPress(Object buttonId)
+}
+
+class Button {
+	private ButtonHandler handler_;
+	private String label_;
+	private Rect   bounds_;
+
+	public Button(String label, Point p, int radius, ButtonHandler handler){
+		handler_ = handler;
+		label_ = label.clone;
+		bounds_ = new Rect(p.x - radius, p.y - radius, radius * 2, radius * 2);
+
+		down_ = false;
+	}
+
+	private boolean down_;
+
+	public void press(){
+		if(handler_ != null){
+			handler_.handleButtonPress(this);
+		}
+	}
+
+	public void pushed(){
+		down_ = true;
+	}
+	public void released(){
+		if(down_){
+			down_ = false;
+			press();
+		}
+	}
+	public void clear(){
+		down_ = false;
+	}
+
+	 public boolean handleEvent(Event event){
+		if(!contains(new Point(event.x, event.y))){
+			if(event.id == Event.MOUSE_UP){
+				clear();
+			}
+			return false;
+		}
+
+		if(event.id == Event.MOUSE_DOWN){
+			pushed();
+			return true;
+		}
+		if(event.id == Event.MOUSE_UP){
+			released();
+			return true;
+		}
+		return false;
+	}
+
+	public boolean contains(Point p){
+		int dx = p.x - bounds_.cx;
+		int dy = p.y - bounds_.cy;
+		double d = Math.sqrt(dx**2 + dy**2);
+		return d < bounds_.h / 2; //TODO: use correct oval check
+	}
+
+	public void paint(Display display) {
+		if(down_){
+			display.setColor(new Color(200, 200, 200));
+		} else {
+			display.setColor(new Color(220, 220, 220));
+		}
+
+		display.fillOval(bounds_.x, bounds_.y, bounds_.w, bounds_.h);
+
+		display.setColor(new Color(30, 30, 30));
+		Point sz = display.measureString(label_);
+		display.drawString(bounds_.cx - sz.x/2, bounds_.cy + sz.y/3, label_);
+	}
+}
+
+class TextListView implements Control {
+	int Padding = 10;
+	int TitleHeight = 20;
+	int TitleMargin = 10;
+
+	private Rect bounds_;
+	private String title_;
+
+	public TextListView(String title, Rect bounds){
+		bounds_ = bounds.clone;
+		title_ = title.clone;
+		lines_ = new List<String>();
+	}
+
+	public void paint(Display display){
+		display.setColor(new Color(240, 240, 240));
+		display.fillRect(bounds_.x, bounds_.y, bounds_.w, bounds_.h);
+
+		display.setColor(new Color(200, 200, 200));
+		display.drawRect(bounds_.x, bounds_.y, bounds_.w, bounds_.h);
+
+		Point CharSize = display.measureString("Q");
+
+		display.setColor(new Color(30, 30, 30));
+		Point cursor = new Point(bounds_.x + Padding, bounds_.y + Padding + CharSize.y);
+
+		display.drawString(cursor.x, cursor.y, title_);
+		cursor.y = cursor.y + CharSize.y + TitleMargin;
+
+		int row = 1;
+		for (String line: lines_){
+			String text = row.toString() + ". " + line;
+			display.drawString(cursor.x, cursor.y, text);
+			cursor.y = cursor.y + CharSize.y;
+			row++;
+		}
+	}
+
+	public boolean handleEvent(Event event){ return false; }
+
+	private List<String> lines_;
+	public void add(String line)    { lines_.add(line); }
+	public void remove(String line) { lines_.remove(line); }
+	public void clear()             { lines_ = new List<String>(); }
+}
+
+class TextLogView implements Control {
+	int Padding = 10;
+
+	private Rect bounds_;
+
+	public TextLogView(Rect bounds){
+		bounds_ = bounds.clone;
+		lines_ = new List<Line>();
+		lineCount_ = 0;
+	}
+
+	public void paint(Display display){
+		display.setColor(new Color(240, 240, 240));
+		display.fillRect(bounds_.x, bounds_.y, bounds_.w, bounds_.h);
+
+		display.setColor(new Color(200, 200, 200));
+		display.drawRect(bounds_.x, bounds_.y, bounds_.w, bounds_.h);
+
+		Point CharSize = display.measureString("Q");
+
+		display.setColor(new Color(30, 30, 30));
+		Point cursor = new Point(bounds_.x + Padding, bounds_.y + CharSize.y);
+
+		int linesInFrame = (bounds_.h - 2 * Padding) / CharSize.y;
+
+		int currentLine = 0;
+		for (Line line: lines_){
+			if(lineCount_ - currentLine <= linesInFrame){
+				if(line.text == "\n"){
+					cursor.x = bounds_.x + Padding;
+					cursor.y = cursor.y + CharSize.y;
+				} else {
+					display.setColor(line.color);
+					display.drawString(cursor.x, cursor.y, line.text);
+
+					Point lineSize = display.measureString(line.text);
+					cursor.x = cursor.x + lineSize.x;
+				}
+			}
+			if(line.text == "\n"){
+				currentLine++;
+			}
+		}
+	}
+
+	public boolean handleEvent(Event event){ return false; }
+
+	class Line {
+		public Line(String atext, Color acolor) {
+			text = atext.clone;
+			color = acolor.clone;
+		}
+		public String text;
+		public Color  color;
+	}
+
+	private List<Line> lines_;
+	private int        lineCount_;
+	public void print(String line, Color color)   {
+		if(line == ""){
+			return;
+		}
+		lines_.add(new Line(line, color));
+		if(line == "\n"){
+			lineCount_++;
+		}
+	}
+	public void println(String line, Color color) {
+		print(line, color);
+		print("\n", color);
+	}
+}
+
+/* Card verification */
+
+interface Card {
+	public int triesLeft();
+	public boolean locked();
+	public boolean verify(String pin);
+}
+
+class Card_Mock implements Card {
+	private int     triesLeft_;
+	private String  pin_;
+
+	public Card_Mock(){
+		triesLeft_ = 3;
+		pin_ = "1234";
+	}
+
+	public int triesLeft()            { return triesLeft_; }
+	public boolean locked()           { return triesLeft_ <= 0; }
+	public boolean verify(String pin) {
+		if(locked()){
+			return false;
+		}
+		boolean success = pin_ == pin;
+		if(success){
+			triesLeft_ = 3;
+		} else {
+			triesLeft_ = triesLeft_ - 1;
+		}
+		return success;
+	}
+}
+
+class CardReader_Mock {
+	private Card current_;
+
+	public CardReader_Mock()      { current_ = null; }
+	public Card current()         { return current_; }
+	public void waitForCard(int timeout) {
+		Thread.sleep(timeout);
+		current_ = new Card_Mock();
+	}
+	public void remove()          { current_ = null; }
+}
+
+/* Book */
+
+interface Item {
+	public double id();
+	public String name();
+}
+
+class ItemSet {
+	private List<Item> items_;
+
+	public ItemSet() {
+		items_ = new List<Item>();
+	}
+
+	public void include(Item item) { if(!contains(item)){ items_.add(item) }; }
+	public void exclude(Item item) { items_.remove(item); }
+	public void clear()            { items_ = new List<Item>(); }
+
+	public List<Item> list()       { return items_; }
+	public boolean contains(Item item) {
+		for(Item existing: items_){
+			if(existing.id() == item.id()){
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+class Book implements Item {
+	private String name_;
+	private double id_;
+
+	public Book(String name) {
+		name_ = name.clone;
+		id_ = Math.random()
+	}
+
+	public double id()   const { return id_;   }
+	public String name() const { return name_; }
+}
+
+interface ItemScanner {
+	public Item scan();
+}
+
+class ItemScanner_Mock implements ItemScanner {
+	public void ItemScanner_Mock(){
+		available_ = new List<Item>();
+
+		available_.add(new Book("War and Peace"));
+		available_.add(new Book("Anna Karenina"));
+		available_.add(new Book("The Kingdom of God is Within You"));
+		available_.add(new Book("Master and Man"))
+	}
+
+	private List<Item> available_;
+	public Item scan(){
+		int i = (Math.random() * 1000.0).toInteger();
+		while(i >= available_.size){
+			i = i - available_.size;
+		}
+
+		return available_.get(i);
+	}
+}
+
+class LinePrinter {
+	public void println(String text) {
+		System.out.println("| " + text);
+	}
+
+	public void cut() {
+		System.out.println("----------------------------------");
+	}
+}
+
+context BorrowLibraryItems implements ButtonHandler {
+	role Guide {
+		public void welcome(){
+			Transcript.line("Welcome to the automatic borrowing machine.");
+			CardReader.validate();
+			Transcript.line("Thank you for using the automated borrowing machine.");
+		}
+
+		public void menu(){
+			BookScanner.scanItem();
+
+			while(true){
+				Transcript.linefeed();
+				Transcript.line("1. Borrow an item.");
+				Transcript.line("2. Finish with a receipt.");
+				Transcript.line("3. Finish without a receipt.");
+
+				Transcript.text("Select: ");
+				String choice = Keypad.readChar();
+				Transcript.line(choice);
+
+				switch(choice){
+					case "1":
+						BookScanner.scanItem();
+						break;
+					case "2":
+						Printer.printReceipt();
+						return;
+					case "3":
+						return;
+					default:
+						Transcript.error("Invalid option.");
+						break;
+				}
+			}
+		}
+	}
+
+	role BookScanner {
+		public void scanItem(){
+			Transcript.line("Place the book under the Scanner.");
+			Item item = scan();
+			CheckoutList.add(item);
+		}
+	} requires {
+		Item scan();
+	}
+
+	role CheckoutList {
+		public void add(Item item) {
+			if(contains(item)){
+				Transcript.warning("'" + item.name() + "' already scanned.");
+			} else {
+				include(item);
+				Transcript.text("'" + item.name() + "' added.");
+				CheckoutListView.update();
+			}
+		}
+
+		public void removeAll()   {
+			clear();
+			Transcript.line("All items removed from checkout list!");
+			CheckoutListView.update();
+		}
+		public List<Item> items() { return list(); }
+	} requires {
+		void    include(Item item);
+		void    exclude(Item item);
+		void    clear();
+		boolean contains(Item item);
+		List<Item> list();
+	}
+
+	role CheckoutListView {
+		public void update(){
+			clear();
+			for(Item item: CheckoutList.items()){
+				add(item.name());
+			}
+			Screen.update();
+		}
+	} requires {
+		void add(String line);
+		void clear();
+	}
+
+	role Printer {
+		public void printReceipt(){
+			cut();
+			println("Borrowed items:");
+			int row = 1;
+			for(Item item: CheckoutList.items()){
+				println(row.toString() + ". " + item.name());
+				row++;
+			}
+			cut();
+		}
+	} requires {
+		void println(String text);
+        void cut();
+	}
+
+	role CardReader {
+		public void validate(){
+			waitForCard(100);
+			if(current() == null){
+				Transcript.error("No card inserted!");
+				return;
+			}
+
+			Card card = current();
+			boolean verified = false;
+
+			while(!card.locked()){
+				String pin = Keypad.enterPin();
+
+				if(!card.verify(pin)){
+					Transcript.error("Invalid PIN. " + card.triesLeft().toString() + " tries left.");
+				} else {
+					verified = true;
+					break;
+				}
+			}
+
+			if(card.locked()){
+				Transcript.error("Card locked!");
+			} else {
+				if (!verified) {
+					Transcript.error("Verification failed!");
+				} else {
+					Guide.menu();
+				}
+			}
+
+			Transcript.line("DON'T FORGET YOUR CARD!");
+		}
+	} requires {
+		public void waitForCard(int timeout);
+		public Card current();
+		public void remove();
+	}
+
+	role Transcript { // should be a prop
+		public void text(String s)       { print  (s,    new Color(30, 30, 30));  Screen.update(); }
+		public void line(String text)    { println(text, new Color(30, 30, 30));  Screen.update(); }
+		public void error(String text)   { println(text, new Color(220, 30, 30)); Screen.update(); }
+		public void warning(String text) { println(text, new Color(180, 180, 30)); Screen.update(); }
+
+		public void passwordChar() { print("*", new Color(30, 30, 180)); Screen.update(); }
+		public void linefeed()     { print("\n", new Color(30, 30, 30)); }
+	} requires {
+		void print(String text, Color color);
+		void println(String text, Color color);
+	}
+
+	role Keypad { // should be a prop
+		public String readChar(){
+			int a = read();
+			assert(a != null);
+			return a.to1CharString();
+		}
+
+		public String enterPin(){
+			Transcript.text("ENTER PIN: ");
+
+			String pin = "";
+			for(int i = 0; i < 4; i++){
+				String key = readChar();
+				pin = pin + key;
+				Transcript.passwordChar();
+			}
+			Transcript.linefeed();
+			return pin;
+		}
+	} requires {
+		int read();
+	}
+
+	role Screen {
+		public void update(){ invalidate(); }
+	} requires {
+		void invalidate();
+	}
+
+	//////////////////////////
+	private Display display_;
+
+	public BorrowLibraryItems(){
+		display_ = new Display(new Point(600, 400));
+		display_.add(new Button("Clear", new Point( 30, 30), 20, this));
+
+		TextLogView  transcript = new TextLogView(new Rect(10, 60, 325, 300));
+		TextListView checkoutlistview = new TextListView("Checkout List", new Rect(355, 60, 235, 300));
+
+		display_.add(checkoutlistview);
+		display_.add(transcript);
+
+		// setup roles
+		Screen = display_;
+		Keypad = new InputStream(display_);
+		Transcript = transcript;
+		CardReader = new CardReader_Mock();
+
+		BookScanner = new ItemScanner_Mock();
+		Printer = new LinePrinter();
+
+		CheckoutList = new ItemSet();
+		CheckoutListView = checkoutlistview;
+	}
+
+	public void handleButtonPress(Object button){
+		CheckoutList.removeAll();
+	}
+
+	public void start(){
+		Guide.welcome();
+	}
+}
+
+new BorrowLibraryItems().start()

--- a/examples/breakout.k
+++ b/examples/breakout.k
@@ -64,7 +64,7 @@ context Display {
 	public void clear()   { panel_.clear(); }
 	public void repaint() { panel_.repaint(); }
 
-	public void fg(Color color) { panel_.setForeground(color); }
+	public void fg(Color color) { panel_.setColor(color); }
 
 	private int floor(double v){ return v.toInteger(); }
 

--- a/examples/breakout.k
+++ b/examples/breakout.k
@@ -61,7 +61,7 @@ context Display {
 	public Vector offset() { return offset_; }
 	public Mouse mouse() { return mouse_; }
 
-	public void clear()   { panel_.removeAll(); }
+	public void clear()   { panel_.clear(); }
 	public void repaint() { panel_.repaint(); }
 
 	public void fg(Color color) { panel_.setForeground(color); }
@@ -679,9 +679,10 @@ context Breakout {
 	public void run(){
 		world_.load();
 		while(true){
+			//TODO: use wall clock for timing
 			double dt = 0.033;
 			world_.step(dt);
-			Thread.sleep(13);
+			Thread.sleep(16);
 		}
 	}
 }

--- a/examples/bug_pong.k
+++ b/examples/bug_pong.k
@@ -1,7 +1,7 @@
 class MyPanel extends Panel {
    int XSIZE = 600;
    int YSIZE = 400;
-   
+
    public int xsize() { return XSIZE }
    public int ysize() { return YSIZE }
 
@@ -19,15 +19,15 @@ class MyPanel extends Panel {
       boolean retval = false;
 
       if (eventId == Event.MOUSE_DOWN) {
-          
+
       } else if (eventId == Event.MOUSE_UP) {
-         
+
       }
       return retval
    }
 
    public Frame frame() { return frame_ }
- 
+
    private Frame frame_
 }
 
@@ -76,17 +76,16 @@ context Arena {
    }
    role ThePanel {
       public void drawCircle(int x, int y, int r) {
-S         setForeground(Color.blue);
+         setColor(Color.blue);
          drawOval(x+r, y+r, r, r)
       }
       public int maxX() { return xsize() }
       public int maxY() { return ysize() }
       public void refresh() { repaint() }
       public void clear() {
-         removeAll();
-         setForeground(Color.white);
+         setColor(Color.white);
          drawRect(0, 0, xsize(), ysize());
-         setForeground(Color.white)
+         setColor(Color.white)
       }
    } requires {
       void drawOval(int x, int y, int h, int w);
@@ -94,8 +93,7 @@ S         setForeground(Color.blue);
       int xsize();
       int ysize();
       void repaint();
-      void removeAll();
-      void setForeground(Color color)
+      void setColor(Color color)
    }
    role Ball {
       public void draw() {

--- a/examples/egon_pong3.k
+++ b/examples/egon_pong3.k
@@ -57,10 +57,10 @@ context Display {
 	public Vector size() { return size_; }
 	public Mouse mouse() { return mouse_; }
 
-	public void clear()   { panel_.removeAll(); }
+	public void clear()   { panel_.clear(); }
 	public void repaint() { panel_.repaint(); }
 
-	public void fg(Color color) { panel_.setForeground(color); }
+	public void fg(Color color) { panel_.setColor(color); }
 
 	private int floor(double v){ return v.toInteger(); }
 
@@ -73,18 +73,16 @@ context Display {
 			floor(2.0*halfsize.y));
 	}
 	public void oval(Vector center, Vector halfsize) {
-		//BUG: fillOval x0, y0 are wrong, currently need to offset them
 		panel_.fillOval(
-			floor(center.x - 2.0*halfsize.x),
-			floor(center.y - 2.0*halfsize.y),
+			floor(center.x - 1.0*halfsize.x),
+			floor(center.y - 1.0*halfsize.y),
 			floor(2.0*halfsize.x),
 			floor(2.0*halfsize.y));
 	}
 	public void circle(Vector center, double radius) {
-		//BUG: fillOval x0, y0 are wrong, currently need to offset them
 		panel_.fillOval(
-			floor(center.x-2.0*radius),
-			floor(center.y-2.0*radius),
+			floor(center.x-1.0*radius),
+			floor(center.y-1.0*radius),
 			floor(2.0*radius),
 			floor(2.0*radius));
 	}

--- a/examples/egons_pong.k
+++ b/examples/egons_pong.k
@@ -75,10 +75,10 @@ context Display {
 	public Vector size() { return size_; }
 	public Mouse mouse() { return panel_.mouse; }
 
-	public void clear()   { panel_.removeAll(); }
+	public void clear()   { panel_.clear(); }
 	public void repaint() { panel_.repaint(); }
 
-	public void fg(Color color) { panel_.setForeground(color); }
+	public void fg(Color color) { panel_.setColor(color); }
 
 	private int floor(double v){ return v.toInteger(); }
 
@@ -91,18 +91,16 @@ context Display {
 			floor(2.0*halfsize.y));
 	}
 	public void oval(Vector center, Vector halfsize) {
-		//BUG: fillOval x0, y0 are wrong, currently need to offset them
 		panel_.fillOval(
-			floor(center.x - 2.0*halfsize.x),
-			floor(center.y - 2.0*halfsize.y),
+			floor(center.x - 1.0*halfsize.x),
+			floor(center.y - 1.0*halfsize.y),
 			floor(2.0*halfsize.x),
 			floor(2.0*halfsize.y));
 	}
 	public void circle(Vector center, double radius) {
-		//BUG: fillOval x0, y0 are wrong, currently need to offset them
 		panel_.fillOval(
-			floor(center.x-2.0*radius),
-			floor(center.y-2.0*radius),
+			floor(center.x-1.0*radius),
+			floor(center.y-1.0*radius),
 			floor(2.0*radius),
 			floor(2.0*radius));
 	}

--- a/examples/gantt1.k
+++ b/examples/gantt1.k
@@ -5,10 +5,10 @@ class MyPanel extends Panel {
       frame_.add("Center", this);
       frame_.resize(600, 400);
       repaint();
-      setForeground(Color.blue);
+      setColor(Color.blue);
       buttons_ = new List<Button>()
    }
-  
+
    public void addButton(Button button) { buttons_.add(button) }
 
    public boolean handleEvent(Event event) {
@@ -37,7 +37,7 @@ class MyPanel extends Panel {
    }
 
    public Frame frame() { return frame_ }
- 
+
    private List<Button> buttons_;
    private Frame frame_
 }
@@ -67,7 +67,7 @@ class Button {
       // In case of a drag that started inside a button
       state_="up"; draw()
    }
- 
+
    public boolean contains(int x, int y) {
       int centerX = x_ + radius_;
       int centerY = y_ + radius_;
@@ -80,15 +80,15 @@ class Button {
       panel_.drawOval(x_, y_, radius_, radius_);
       panel_.drawString(x_ + radius_ - ((label_.length() * 6) / 2),
                         y_+ radius_ + 6 , label_)
-      Color saveColor = panel_.getForeground();
+      Color saveColor = panel_.getColor();
       if (state_ == "down") {
-         panel_.setForeground(Color.blue);
+         panel_.setColor(Color.blue);
          panel_.fillOval(x_, y_, radius_, radius_)
       } else {
-         panel_.setForeground(new Color(0, 255, 255));
+         panel_.setColor(new Color(0, 255, 255));
          panel_.fillOval(x_+2, y_+1, radius_-2, radius_-1)
       }
-      panel_.setForeground(saveColor)
+      panel_.setColor(saveColor)
    }
 
    public int x() { return x_ }

--- a/examples/keypad.k
+++ b/examples/keypad.k
@@ -1,0 +1,248 @@
+// UI library
+class Rect {
+	public int x, y;
+	public int w, h;
+
+	public Rect(int ax, int ay, int aw, int ah){
+		x = ax.clone; y = ay.clone; w = aw.clone; h = ah.clone;
+	}
+
+	public int cx(){ return x + w / 2; }
+	public int cy(){ return y + h / 2; }
+
+	public boolean contains(Point p){
+		return (x <= p.x) && (p.x < x + w) && (y <= p.y) && (p.y < y + h);
+	}
+}
+
+class Mouse {
+	public Point position;
+	public boolean down;
+	public boolean released;
+
+	public Mouse(){
+		position = new Point(0, 0);
+	}
+
+	public void clear(){
+		released = false;
+	}
+
+	public boolean clicked(Rect r){
+		if(!r.contains(position)){
+			return false;
+		}
+		if(released){
+			released = false;
+			return true;
+		}
+		return false;
+	}
+}
+
+class MousePanel extends Panel {
+	public Mouse mouse;
+	public MousePanel(){
+		Panel()
+		mouse = new Mouse();
+	}
+
+	// TODO: use a list to store clicks, otherwise double-clicks and
+	//       quick-events may get lost
+	public boolean handleEvent(Event event) {
+		if(event == null){
+			return false;
+		}
+		if(event.id == Event.MOUSE_MOVE){
+			mouse.position.x = event.x.clone;
+			mouse.position.y = event.y.clone;
+		}
+		if(event.id == Event.MOUSE_DOWN){
+			mouse.down = true;
+		}
+		if(event.id == Event.MOUSE_UP){
+			mouse.down = false;
+			mouse.released = true;
+		}
+		return true;
+	}
+}
+
+// Implements basic immediate mode UI
+context BasicUI {
+	private MousePanel panel_;
+	private Frame frame_;
+	private Point size_;
+
+	private boolean breaknext_;
+
+	public BasicUI(){
+		size_ = new Point(640, 480);
+		panel_ = new MousePanel();
+		breaknext_ = false;
+
+		frame_ = new Frame("");
+		frame_.add("Center", panel_);
+		frame_.resize(size_.x, size_.y);
+
+		frame_.setVisible(true);
+	}
+
+	public Point size() { return size_; }
+	public Mouse mouse() { return panel_.mouse; }
+
+	public void clear()   { panel_.clear(); }
+	public void repaint() { panel_.repaint(); }
+
+	public boolean nextEvent() {
+		mouse().clear();
+		if(breaknext_){
+			breaknext_ = false;
+			return false;
+		}
+		repaint();
+		clear();
+		Thread.sleep(33);
+		return true;
+	}
+	public void breakonce() {
+		breaknext_ = true;
+	}
+
+	public void color(Color color) { panel_.setColor(color); }
+	public void rect(Rect r){
+		panel_.fillRect(r.x, r.y, r.w, r.h);
+	}
+	public void text(String s, Rect r){
+		panel_.drawString(r.x + 8 + 10, r.cy + 5, s);
+	}
+	public boolean button(String s, Rect r){
+		if(r.contains(mouse().position)){
+			color(new Color(240, 240, 240));
+		} else {
+			color(new Color(200, 200, 200));
+		}
+		rect(r);
+		color(Color.black);
+		text(s, r);
+		return mouse().clicked(r);
+	}
+}
+
+class TileLayout {
+	private Point start;
+	private Point at;
+	private Point size;
+	private int column;
+	private int columns;
+	private int padding;
+
+	public TileLayout(Point astart, Point asize, int acolumns) {
+		start = new Point(astart.x.clone, astart.y.clone);
+		at  = new Point(astart.x.clone, astart.y.clone);
+		size  = new Point(asize.x.clone, asize.y.clone);
+		column = 0;
+		columns = acolumns.clone;
+		padding = 5;
+	}
+
+	public Rect row(){
+		int left = columns - column;
+		Rect r = new Rect(at.x, at.y, (size.x + padding) * left - padding, size.y);
+		column = columns.clone;
+		advance();
+		return r;
+	}
+
+	public Rect next(){
+		Rect r = new Rect(at.x, at.y, size.x, size.y);
+		advance();
+		return r;
+	}
+
+	public void advance(){
+		column++;
+		if(column >= columns){
+			column = 0;
+			at.x = start.x.clone;
+			at.y = at.y + size.y + padding;
+		} else {
+			at.x = at.x + size.x + padding;
+		}
+	}
+}
+
+class Keypad {
+	private String content_;
+	public Keypad(){
+		content_ = "";
+	}
+
+	public void clear(){ content_ = ""; }
+	public void backspace(){
+		if(content_.length > 0){
+			content_ = content_.substring(0, content_.length - 1);
+		}
+	}
+	public String content(){ return content_; }
+	public void input(String key){ content_ = content_ + key; }
+}
+
+context App {
+	public App(){
+		UI = new BasicUI();
+		Keys = new Keypad();
+	}
+	public void run(){
+		UI.eventLoop();
+	}
+
+	role Keys {} requires {
+		public void clear();
+		public void backspace();
+		public String content();
+		public void input(String key);
+	}
+
+	role UI {
+		public void eventLoop(){
+			while(true){
+				while(nextEvent()){
+					buttons();
+				}
+				System.out.println("RESULT: " + Keys.content());
+
+				// alternatively go to a second screen
+			}
+		}
+
+		public void buttons(){
+			TileLayout lay = new TileLayout(new Point(20, 20), new Point(50, 50), 3);
+
+			button(Keys.content(), lay.row);
+
+			if(button("C", lay.next)){ Keys.clear();     }
+			if(button("<", lay.next)){ Keys.backspace(); }
+			if(button("R", lay.next)){ breakonce() }
+
+			if(button("1", lay.next)){ Keys.input("1"); }
+			if(button("2", lay.next)){ Keys.input("2"); }
+			if(button("3", lay.next)){ Keys.input("3"); }
+
+			if(button("4", lay.next)){ Keys.input("4"); }
+			if(button("5", lay.next)){ Keys.input("5"); }
+			if(button("6", lay.next)){ Keys.input("6"); }
+
+			if(button("7", lay.next)){ Keys.input("7"); }
+			if(button("8", lay.next)){ Keys.input("8"); }
+			if(button("9", lay.next)){ Keys.input("9"); }
+		}
+	} requires {
+		void breakonce();
+		boolean nextEvent();
+		boolean button(String s, Rect r);
+	}
+}
+
+new App().run()
+

--- a/examples/keypad.k
+++ b/examples/keypad.k
@@ -114,7 +114,8 @@ context BasicUI {
 		panel_.fillRect(r.x, r.y, r.w, r.h);
 	}
 	public void text(String s, Rect r){
-		panel_.drawString(r.x + 8 + 10, r.cy + 5, s);
+		Point sz = panel_.measureString(s);
+		panel_.drawString(r.cx - sz.x / 2, r.cy + sz.y / 2, s);
 	}
 	public boolean button(String s, Rect r){
 		if(r.contains(mouse().position)){

--- a/examples/panel1.k
+++ b/examples/panel1.k
@@ -34,15 +34,22 @@ class PanelTest {
       Frame frame = new Frame("First Frame");
       frame.add("Center", panel);
       frame.resize(300, 300);
-      panel.setForeground(Color.black);
-      panel.drawString(120, 120, "Hello world");
-      panel.setForeground(Color.green);
-      panel.drawLine(120, 122, 190, 122);
-      panel.setForeground(Color.blue);
-      panel.drawRect(20, 20, 70, 100);
-      panel.setForeground(Color.red);
-      panel.drawOval(45, 100, 80, 80);
       frame.setVisible(true)
+
+      while(true){
+        panel.clear();
+        panel.setColor(Color.black);
+        panel.drawString(120, 120, "Hello world");
+        panel.setColor(Color.green);
+        panel.drawLine(120, 122, 190, 122);
+        panel.setColor(Color.blue);
+        panel.drawRect(20, 20, 70, 100);
+        panel.setColor(Color.red);
+        panel.drawOval(45, 100, 80, 80);
+        panel.repaint();
+
+        Thread.sleep(1000);
+      }
    }
 }
 

--- a/examples/pong.k
+++ b/examples/pong.k
@@ -11,7 +11,7 @@ class MyFrame extends Frame {
 class MyPanel extends Panel {
    int XSIZE = 1000;
    int YSIZE = 600;
-   
+
    public int xsize() { return XSIZE }
    public int ysize() { return YSIZE }
 
@@ -41,7 +41,7 @@ class MyPanel extends Panel {
    }
 
    public Frame frame() { return frame_ }
- 
+
    private Frame frame_;
    private EventHandler eventHandler_
 }
@@ -64,19 +64,18 @@ context Arena implements EventHandler {
    public Arena() {
       MyPanel panel = new MyPanel();
       ThePanel = panel;
-      ThePanel.clear();
       Ball = new BallObject(50, 50);
       Paddle = new Point(450, 560);
       panel.setEventHandler(this)
    }
    public void run() {
       do {
-         ThePanel.clearObjects();
-         Paddle.erase();
+         ThePanel.clear();
          Paddle.draw();
-         //Ball.erase()
          Ball.velocityAdjust();
-         Ball.draw();
+         Ball.draw()
+         ThePanel.flush();
+
          Ball.step();
          Thread.sleep(20)
       } while (true)
@@ -90,8 +89,7 @@ context Arena implements EventHandler {
       }
       public int maxX() { return xsize() }
       public int maxY() { return ysize() }
-      public void setColor(Color c) { setForeground(c) }
-      public void clearObjects() { removeAll() }
+      public void flush() { repaint() }
       public void clear() {
          setColor(new Color(227, 221, 240));
          fillRect(0, 0, maxX()-1, maxY()-1)
@@ -102,8 +100,8 @@ context Arena implements EventHandler {
       void fillRect(int x, int y, int h, int w);
       int xsize();
       int ysize();
-      void removeAll();
-      void setForeground(Color color)
+      void setColor(Color color);
+      void repaint();
    }
    role Paddle {
       public int thickness() const { return 10 }

--- a/examples/pong2.k
+++ b/examples/pong2.k
@@ -7,7 +7,7 @@ interface EventHandler {
 class MyPanel extends Panel {
    int XSIZE = 1000;
    int YSIZE = 600;
-   
+
    public int xsize() const { return XSIZE }
    public int ysize() const { return YSIZE }
 
@@ -37,7 +37,7 @@ class MyPanel extends Panel {
    }
 
    public Frame frame() { return frame_ }
- 
+
    private Frame frame_;
    private EventHandler eventHandler_
 }
@@ -67,13 +67,12 @@ context Arena implements EventHandler {
    }
    public void run() {
       do {
-         THE_PANEL.clearObjects();
-         PADDLE.erase();
+         THE_PANEL.clear();
          PADDLE.draw();
          BALL.draw()
          BALL.velocityAdjust();
-         BALL.erase();
          BALL.step();
+         THE_PANEL.flush();
          Thread.sleep(20)
       } while (true)
    }
@@ -88,8 +87,7 @@ context Arena implements EventHandler {
       }
       public int maxX() const { return xsize() }
       public int maxY() const { return ysize() }
-      public void setColor(Color c) { setForeground(c) }
-      public void clearObjects() { removeAll() }
+      public void flush() { repaint(); }
       public void clear() {
          setColor(new Color(227, 221, 240));
          fillRect(0, 0, maxX()-1, maxY()-1)
@@ -100,8 +98,8 @@ context Arena implements EventHandler {
       void fillRect(int x, int y, int h, int w);
       int xsize() const;
       int ysize() const;
-      void removeAll();
-      void setForeground(Color color)
+      void setColor(Color color);
+      void repaint();
    }
    role PADDLE {
       public int thickness() const { return 10 }

--- a/src/main/java/info/fulloo/trygve/add_ons/PanelClass.java
+++ b/src/main/java/info/fulloo/trygve/add_ons/PanelClass.java
@@ -196,7 +196,7 @@ public final class PanelClass {
 			try {
 				thePanel.setColor(color);
 			} catch (final Exception e) {
-				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.setBackground.", "", "", "");
+				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.setColor.", "", "", "");
 				RTMessage.printMiniStackStatus();
 				return null;
 			}
@@ -219,7 +219,7 @@ public final class PanelClass {
 				final RTType rTColor = InterpretiveCodeGenerator.scopeToRTTypeDeclaration(colorType.enclosedScope());
 				value = new RTColorObject(cRetval.getRed(), cRetval.getGreen(), cRetval.getBlue(), rTColor);
 			} catch (final Exception e) {
-				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.getBackground.", "", "", "");
+				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.getColor.", "", "", "");
 				RTMessage.printMiniStackStatus();
 				return null;
 			}

--- a/src/main/java/info/fulloo/trygve/add_ons/PanelClass.java
+++ b/src/main/java/info/fulloo/trygve/add_ons/PanelClass.java
@@ -1,13 +1,10 @@
 package info.fulloo.trygve.add_ons;
 
-import java.awt.Color;
 import java.awt.Event;
-import java.awt.Graphics;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import info.fulloo.trygve.code_generation.InterpretiveCodeGenerator;
 import info.fulloo.trygve.declarations.AccessQualifier;
 import info.fulloo.trygve.declarations.FormalParameterList;
 import info.fulloo.trygve.declarations.Type;
@@ -22,7 +19,6 @@ import info.fulloo.trygve.expressions.Expression;
 import info.fulloo.trygve.graphics.GraphicsPanel;
 import info.fulloo.trygve.run_time.RTClass.RTObjectClass;
 import info.fulloo.trygve.run_time.RTCode;
-import info.fulloo.trygve.run_time.RTColorObject;
 import info.fulloo.trygve.run_time.RTDynamicScope;
 import info.fulloo.trygve.run_time.RTClass;
 import info.fulloo.trygve.run_time.RTClass.RTObjectClass.RTHalt;   
@@ -110,18 +106,13 @@ public final class PanelClass {
 
 			// arguments are in reverse order
 			declarePanelMethod("Panel", null, null, null, false);
-			declarePanelMethod("setBackground", voidType, asList("color"), asList(colorType), false);
-			declarePanelMethod("getBackground", colorType, null, null, true);
-			declarePanelMethod("setForeground", voidType, asList("color"), asList(colorType), false);
-			declarePanelMethod("getForeground", colorType, null, null, true);
+			declarePanelMethod("setColor", voidType, asList("color"), asList(colorType), false);
 			declarePanelMethod("drawLine", voidType, asList("toY", "toX", "fromY", "fromX"), asList(intType, intType, intType, intType), false);
 			declarePanelMethod("drawRect", voidType, asList("height", "width", "fromY", "fromX"), asList(intType, intType, intType, intType), false);
 			declarePanelMethod("fillRect", voidType, asList("height", "width", "fromY", "fromX"), asList(intType, intType, intType, intType), false);
 			declarePanelMethod("drawOval", voidType, asList("height", "width", "topY", "leftX"), asList(intType, intType, intType, intType), false);
 			declarePanelMethod("fillOval", voidType, asList("height", "width", "topY", "leftX"), asList(intType, intType, intType, intType), false);
-			declarePanelMethod("drawString", objectType, asList("text", "y", "x"), asList(stringType, intType, intType), false);
-			declarePanelMethod("removeAll", voidType, null, null, false);
-			declarePanelMethod("remove", voidType, asList("component"), asList(objectType), false);
+			declarePanelMethod("drawString", voidType, asList("text", "y", "x"), asList(stringType, intType, intType), false);
 			declarePanelMethod("repaint", voidType, null, null, false);
 			declarePanelMethod("clear", voidType, null, null, false);
 			
@@ -199,9 +190,9 @@ public final class PanelClass {
 			return null;	// halt the machine
 		}
 	}
-	public static class RTSetBackgroundCode extends RTPanelCommon {
-		public RTSetBackgroundCode(final StaticScope enclosingMethodScope) {
-			super("Panel", "setBackground", asList("color"), asList("Color"), enclosingMethodScope, StaticScope.globalScope().lookupTypeDeclaration("void"));
+	public static class RTSetColorCode extends RTPanelCommon {
+		public RTSetColorCode(final StaticScope enclosingMethodScope) {
+			super("Panel", "setColor", asList("color"), asList("Color"), enclosingMethodScope, StaticScope.globalScope().lookupTypeDeclaration("void"));
 		}
 		@Override public RTCode runDetails(final RTObject myEnclosedScope, final GraphicsPanel thePanel) {
 			assert null != thePanel;
@@ -209,84 +200,12 @@ public final class PanelClass {
 			final RTObject color = (RTObject)activationRecord.getObject("color");
 			
 			try {
-				thePanel.setBackground(color);
+				thePanel.setColor(color);
 			} catch (final Exception e) {
 				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.setBackground.", "", "", "");
 				RTMessage.printMiniStackStatus();
 				return null;
 			}
-			
-			return super.nextCode();
-		}
-	}
-	public static class RTGetBackgroundCode extends RTPanelCommon {
-		public RTGetBackgroundCode(final StaticScope enclosingMethodScope) {
-			super("Panel", "getBackground", null, null, enclosingMethodScope, StaticScope.globalScope().lookupTypeDeclaration("Color"));
-		}
-		@Override public RTCode runDetails(final RTObject myEnclosedScope, final GraphicsPanel thePanel) {
-			assert null != thePanel;
-			RTObject value = null;
-			final RTDynamicScope activationRecord = RunTimeEnvironment.runTimeEnvironment_.currentDynamicScope();
-			
-			try {
-				final Color cRetval = thePanel.getForeground();
-				final Type colorType = StaticScope.globalScope().lookupTypeDeclaration("Color");
-				final RTType rTColor = InterpretiveCodeGenerator.scopeToRTTypeDeclaration(colorType.enclosedScope());
-				value = new RTColorObject(cRetval.getRed(), cRetval.getGreen(), cRetval.getBlue(), rTColor);
-			} catch (final Exception e) {
-				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.getBackground.", "", "", "");
-				RTMessage.printMiniStackStatus();
-				return null;
-			}
-			
-			this.addRetvalTo(activationRecord);
-			activationRecord.setNamedSlotToValue("ret$val", value);
-			
-			return super.nextCode();
-		}
-	}
-	public static class RTSetForegroundCode extends RTPanelCommon {
-		public RTSetForegroundCode(final StaticScope enclosingMethodScope) {
-			super("Panel", "setForeground", asList("color"), asList("Color"), enclosingMethodScope, StaticScope.globalScope().lookupTypeDeclaration("void"));
-		}
-		@Override public RTCode runDetails(final RTObject myEnclosedScope, final GraphicsPanel thePanel) {
-			assert null != thePanel;
-			final RTDynamicScope activationRecord = RunTimeEnvironment.runTimeEnvironment_.currentDynamicScope();
-			final RTObject color = (RTObject)activationRecord.getObject("color");
-			
-			try {
-				thePanel.setForeground(color);
-			} catch (final Exception e) {
-				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.setForeground.", "", "", "");
-				RTMessage.printMiniStackStatus();
-				return null;
-			}
-			
-			return super.nextCode();
-		}
-	}
-	public static class RTGetForegroundCode extends RTPanelCommon {
-		public RTGetForegroundCode(final StaticScope enclosingMethodScope) {
-			super("Panel", "getForeground", null, null, enclosingMethodScope, StaticScope.globalScope().lookupTypeDeclaration("Color"));
-		}
-		@Override public RTCode runDetails(final RTObject myEnclosedScope, final GraphicsPanel thePanel) {
-			assert null != thePanel;
-			RTObject value = null;
-			final RTDynamicScope activationRecord = RunTimeEnvironment.runTimeEnvironment_.currentDynamicScope();
-			
-			try {
-				final Color cRetval = thePanel.getForeground();
-				final Type colorType = StaticScope.globalScope().lookupTypeDeclaration("Color");
-				final RTType rTColor = InterpretiveCodeGenerator.scopeToRTTypeDeclaration(colorType.enclosedScope());
-				value = new RTColorObject(cRetval.getRed(), cRetval.getGreen(), cRetval.getBlue(), rTColor);
-			} catch (final Exception e) {
-				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.getForeground.", "", "", "");
-				RTMessage.printMiniStackStatus();
-				return null;
-			}
-			
-			this.addRetvalTo(activationRecord);
-			activationRecord.setNamedSlotToValue("ret$val", value);
 			
 			return super.nextCode();
 		}
@@ -423,56 +342,13 @@ public final class PanelClass {
 			final RTObject text = (RTObject)activationRecord.getObject("text");
 			RTObject value = null;
 			try {
-				// Returns a magic cookie that later can be used to
-				// remove the String from the container
-				value = thePanel.drawString(x, y, text);
+				thePanel.drawString(x, y, text);
 			} catch (final Exception e) {
 				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.drawString(`", ((RTStringObject)text).toString(), "'.", "");
 				RTMessage.printMiniStackStatus();
 				return null;
 			}
-			
-			this.addRetvalTo(activationRecord);
-			activationRecord.setNamedSlotToValue("ret$val", value);
-			
-			return super.nextCode();
-		}
-	}
-	public static class RTRemoveAllCode extends RTPanelCommon {
-		public RTRemoveAllCode(final StaticScope enclosingMethodScope) {
-			super("Panel", "removeAll", null, null, enclosingMethodScope, StaticScope.globalScope().lookupTypeDeclaration("void"));
-		}
-		@Override public RTCode runDetails(final RTObject myEnclosedScope, final GraphicsPanel thePanel) {
-			assert null != thePanel;
-			try {
-				thePanel.removeAll();
-				thePanel.revalidate();
-			} catch (final Exception e) {
-				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.removeAll()", ".", "", "");
-				RTMessage.printMiniStackStatus();
-				return null;
-			}
-			
-			return super.nextCode();
-		}
-	}
-	public static class RTRemoveCode extends RTPanelCommon {
-		public RTRemoveCode(final StaticScope enclosingMethodScope) {
-			super("Panel", "remove", asList("component"), asList("Object"), enclosingMethodScope, StaticScope.globalScope().lookupTypeDeclaration("void"));
-		}
-		@Override public RTCode runDetails(final RTObject myEnclosedScope, final GraphicsPanel thePanel) {
-			assert null != thePanel;
-			try {
-				final RTDynamicScope activationRecord = RunTimeEnvironment.runTimeEnvironment_.currentDynamicScope();
-				final RTObject component = (RTObject)activationRecord.getObject("component");
-				thePanel.remove(component);
-				thePanel.revalidate();
-			} catch (final Exception e) {
-				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.remove(Object)", ".", "", "");
-				RTMessage.printMiniStackStatus();
-				return null;
-			}
-			
+
 			return super.nextCode();
 		}
 	}

--- a/src/main/java/info/fulloo/trygve/add_ons/PanelClass.java
+++ b/src/main/java/info/fulloo/trygve/add_ons/PanelClass.java
@@ -483,15 +483,7 @@ public final class PanelClass {
 		@Override public RTCode runDetails(final RTObject myEnclosedScope, final GraphicsPanel thePanel) {
 			assert null != thePanel;
 			try{
-				final Graphics g = thePanel.getGraphics();
-				final int w = thePanel.getWidth(), h = thePanel.getHeight();
-				if (null != g && w > 0 && h > 0) {
-					g.clearRect(0, 0, w, h);
-					g.setColor(Color.white);
-				    g.fillRect(0, 0, w, h);
-				    g.setColor(Color.black);
-				}
-				
+				thePanel.clear();
 			} catch (final Exception e) {
 				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.clear()", ".", "", "");
 				RTMessage.printMiniStackStatus();
@@ -508,22 +500,8 @@ public final class PanelClass {
 		@Override public RTCode runDetails(final RTObject myEnclosedScope, final GraphicsPanel thePanel) {
 			assert null != thePanel;
 			try{
-				// Re-validate call suggested by: http://stackoverflow.com/questions/18001087/jpanel-removeall-doesnt-get-rid-of-previous-components
-				thePanel.revalidate();
-				
-				// AWT repaint() just schedules a future task on the GUI thread.
-				// Because some of our graphics activities (like erasure) are done
-				// directly, this sometimes leads to interleaving and messed-up
-				// windows. So, concrete advice to the contrary not withstanding,
-				// we call paint directly.
-				//
-				// See: http://www.scs.ryerson.ca/mes/courses/cps530/programs/threads/Repaint/
-				//
-				final Graphics g = thePanel.getGraphics();
-				if (null != g) {
-					// thePanel.paint(g);
-					thePanel.repaint();
-				}
+				thePanel.flipBuffers();
+				thePanel.repaint();
 			} catch (final Exception e) {
 				ErrorLogger.error(ErrorIncidenceType.Runtime, 0, "FATAL: Bad call to Panel.repaint(`", "", "'.", "");
 				RTMessage.printMiniStackStatus();

--- a/src/main/java/info/fulloo/trygve/add_ons/PanelClass.java
+++ b/src/main/java/info/fulloo/trygve/add_ons/PanelClass.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import info.fulloo.trygve.add_ons.PointClass.RTPointObject;
 import info.fulloo.trygve.code_generation.InterpretiveCodeGenerator;
 import info.fulloo.trygve.declarations.AccessQualifier;
 import info.fulloo.trygve.declarations.FormalParameterList;
@@ -86,7 +87,8 @@ public final class PanelClass {
 			final Type colorType = globalScope.lookupTypeDeclaration("Color");
 			final Type stringType = globalScope.lookupTypeDeclaration("String");
 			final Type objectType = globalScope.lookupTypeDeclaration("Object");
-			
+			final Type pointType = globalScope.lookupTypeDeclaration("Point");
+
 			final ClassDeclaration objectBaseClass = globalScope.lookupClassDeclaration("Object");
 			assert null != objectBaseClass;
 
@@ -107,6 +109,7 @@ public final class PanelClass {
 			declarePanelMethod("drawOval", voidType, asList("height", "width", "topY", "leftX"), asList(intType, intType, intType, intType), false);
 			declarePanelMethod("fillOval", voidType, asList("height", "width", "topY", "leftX"), asList(intType, intType, intType, intType), false);
 			declarePanelMethod("drawString", voidType, asList("text", "y", "x"), asList(stringType, intType, intType), false);
+			declarePanelMethod("measureString", pointType, asList("text"), asList(stringType), false);
 			declarePanelMethod("repaint", voidType, null, null, false);
 			declarePanelMethod("clear", voidType, null, null, false);
 			
@@ -352,7 +355,7 @@ public final class PanelClass {
 	}
 	public static class RTDrawStringCode extends RTPanelCommon {
 		public RTDrawStringCode(final StaticScope enclosingMethodScope) {
-			super("Panel", "drawString", asList("x", "y", "text"), asList("int", "int", "String"), enclosingMethodScope, StaticScope.globalScope().lookupTypeDeclaration("Object"));
+			super("Panel", "drawString", asList("x", "y", "text"), asList("int", "int", "String"), enclosingMethodScope, StaticScope.globalScope().lookupTypeDeclaration("void"));
 		}
 		@Override public RTCode runDetails(final RTObject myEnclosedScope, final GraphicsPanel thePanel) {
 			assert null != thePanel;
@@ -360,7 +363,6 @@ public final class PanelClass {
 			final RTObject x = (RTObject)activationRecord.getObject("x");
 			final RTObject y = (RTObject)activationRecord.getObject("y");
 			final RTObject text = (RTObject)activationRecord.getObject("text");
-			RTObject value = null;
 			try {
 				thePanel.drawString(x, y, text);
 			} catch (final Exception e) {
@@ -368,6 +370,24 @@ public final class PanelClass {
 				RTMessage.printMiniStackStatus();
 				return null;
 			}
+
+			return super.nextCode();
+		}
+	}
+	public static class RTMeasureString extends RTPanelCommon {
+		public RTMeasureString(final StaticScope enclosingMethodScope) {
+			super("Panel", "measureString", asList("text"), asList("String"), enclosingMethodScope, StaticScope.globalScope().lookupTypeDeclaration("Point"));
+		}
+		@Override public RTCode runDetails(final RTObject myEnclosedScope, final GraphicsPanel thePanel) {
+			assert null != thePanel;
+			final RTDynamicScope activationRecord = RunTimeEnvironment.runTimeEnvironment_.currentDynamicScope();
+			final RTObject text = (RTObject)activationRecord.getObject("text");
+
+			final Point rawRetval = thePanel.measureString(text);
+			final RTPointObject retval = new RTPointObject(rawRetval);
+
+			addRetvalTo(activationRecord);
+			activationRecord.setObject("ret$val", retval);
 
 			return super.nextCode();
 		}

--- a/src/main/java/info/fulloo/trygve/code_generation/InterpretiveCodeGenerator.java
+++ b/src/main/java/info/fulloo/trygve/code_generation/InterpretiveCodeGenerator.java
@@ -724,6 +724,9 @@ public class InterpretiveCodeGenerator implements CodeGenerator {
 			} else if (methodDeclaration.name().equals("clear")) {
 				panelCode.add(new PanelClass.RTClearCode(methodDeclaration.enclosedScope()));
 				retvalType = RetvalTypes.none;
+			} else if (methodDeclaration.name().equals("getColor")) {
+				panelCode.add(new PanelClass.RTGetColorCode(methodDeclaration.enclosedScope()));
+				retvalType = RetvalTypes.usingColor;
 			} else {
 				assert false;
 			}

--- a/src/main/java/info/fulloo/trygve/code_generation/InterpretiveCodeGenerator.java
+++ b/src/main/java/info/fulloo/trygve/code_generation/InterpretiveCodeGenerator.java
@@ -714,16 +714,14 @@ public class InterpretiveCodeGenerator implements CodeGenerator {
 		
 		if (formalParameterList.count() == 1) {
 			rtTypeDeclaration.addMethod(methodDeclaration.name(), rtMethod);
+			retvalType = RetvalTypes.none;
 			
 			if (methodDeclaration.name().equals("Panel")) {
 				panelCode.add(new PanelClass.RTPanelCtorCode(methodDeclaration.enclosedScope()));
-				retvalType = RetvalTypes.none;
 			} else if (methodDeclaration.name().equals("repaint")) {
 				panelCode.add(new PanelClass.RTRepaintCode(methodDeclaration.enclosedScope()));
-				retvalType = RetvalTypes.none;
 			} else if (methodDeclaration.name().equals("clear")) {
 				panelCode.add(new PanelClass.RTClearCode(methodDeclaration.enclosedScope()));
-				retvalType = RetvalTypes.none;
 			} else if (methodDeclaration.name().equals("getColor")) {
 				panelCode.add(new PanelClass.RTGetColorCode(methodDeclaration.enclosedScope()));
 				retvalType = RetvalTypes.usingColor;
@@ -732,13 +730,16 @@ public class InterpretiveCodeGenerator implements CodeGenerator {
 			}
 		} else if (formalParameterList.count() == 2) {
 			rtTypeDeclaration.addMethod(methodDeclaration.name(), rtMethod);
-		
+			retvalType = RetvalTypes.none;
+
 			if (methodDeclaration.name().equals("setColor")) {
 				panelCode.add(new PanelClass.RTSetColorCode(methodDeclaration.enclosedScope()));
+			} else if (methodDeclaration.name().equals("measureString")) {
+				retvalType = RetvalTypes.usingPoint;
+				panelCode.add(new PanelClass.RTMeasureString(methodDeclaration.enclosedScope()));
 			} else {
 				assert false;
 			}
-			retvalType = RetvalTypes.none;
 		} else if (formalParameterList.count() == 4) {
 			rtTypeDeclaration.addMethod(methodDeclaration.name(), rtMethod);
 			retvalType = RetvalTypes.none;
@@ -750,6 +751,7 @@ public class InterpretiveCodeGenerator implements CodeGenerator {
 			}
 		} else if (formalParameterList.count() == 5) {
 			rtTypeDeclaration.addMethod(methodDeclaration.name(), rtMethod);
+			retvalType = RetvalTypes.none;
 			
 			if (methodDeclaration.name().equals("drawLine")) {
 				panelCode.add(new PanelClass.RTDrawLineCode(methodDeclaration.enclosedScope()));
@@ -764,7 +766,6 @@ public class InterpretiveCodeGenerator implements CodeGenerator {
 			} else {
 				assert false;
 			}
-			retvalType = RetvalTypes.none;
 		} else {
 			assert false;
 		}

--- a/src/main/java/info/fulloo/trygve/code_generation/InterpretiveCodeGenerator.java
+++ b/src/main/java/info/fulloo/trygve/code_generation/InterpretiveCodeGenerator.java
@@ -718,33 +718,20 @@ public class InterpretiveCodeGenerator implements CodeGenerator {
 			if (methodDeclaration.name().equals("Panel")) {
 				panelCode.add(new PanelClass.RTPanelCtorCode(methodDeclaration.enclosedScope()));
 				retvalType = RetvalTypes.none;
-			} else if (methodDeclaration.name().equals("removeAll")) {
-				panelCode.add(new PanelClass.RTRemoveAllCode(methodDeclaration.enclosedScope()));
-				retvalType = RetvalTypes.none;
 			} else if (methodDeclaration.name().equals("repaint")) {
 				panelCode.add(new PanelClass.RTRepaintCode(methodDeclaration.enclosedScope()));
 				retvalType = RetvalTypes.none;
 			} else if (methodDeclaration.name().equals("clear")) {
 				panelCode.add(new PanelClass.RTClearCode(methodDeclaration.enclosedScope()));
 				retvalType = RetvalTypes.none;
-			} else if (methodDeclaration.name().equals("getBackground")) {
-				panelCode.add(new PanelClass.RTGetBackgroundCode(methodDeclaration.enclosedScope()));
-				retvalType = RetvalTypes.usingColor;
-			} else if (methodDeclaration.name().equals("getForeground")) {
-				panelCode.add(new PanelClass.RTGetForegroundCode(methodDeclaration.enclosedScope()));
-				retvalType = RetvalTypes.usingColor;
 			} else {
 				assert false;
 			}
 		} else if (formalParameterList.count() == 2) {
 			rtTypeDeclaration.addMethod(methodDeclaration.name(), rtMethod);
 		
-			if (methodDeclaration.name().equals("setBackground")) {
-				panelCode.add(new PanelClass.RTSetBackgroundCode(methodDeclaration.enclosedScope()));
-			} else if (methodDeclaration.name().equals("setForeground")) {
-				panelCode.add(new PanelClass.RTSetForegroundCode(methodDeclaration.enclosedScope()));
-			} else if (methodDeclaration.name().equals("remove")) {
-				panelCode.add(new PanelClass.RTRemoveCode(methodDeclaration.enclosedScope()));
+			if (methodDeclaration.name().equals("setColor")) {
+				panelCode.add(new PanelClass.RTSetColorCode(methodDeclaration.enclosedScope()));
 			} else {
 				assert false;
 			}
@@ -755,7 +742,6 @@ public class InterpretiveCodeGenerator implements CodeGenerator {
 			
 			if (methodDeclaration.name().equals("drawString")) {
 				panelCode.add(new PanelClass.RTDrawStringCode(methodDeclaration.enclosedScope()));
-				retvalType = RetvalTypes.usingString;
 			} else {
 				assert false;
 			}

--- a/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
+++ b/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
@@ -388,8 +388,11 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 				height = 480;
 			}
 
+			// when the panel isn't put on the screen this can fail
 			image = createImage(width, height);
-			g = image.getGraphics();
+			if(image != null){
+				g = image.getGraphics();
+			}
 		}
 	}
 

--- a/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
+++ b/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
@@ -357,8 +357,13 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 			Buffer temp = back;
 			back = front;
 			front = temp;
+
+			back.updateSize();
+			// This hides the usage of the double-buffer at the cost of performance
+			if(front.image != null && back.g != null){
+				back.g.drawImage(front.image, 0, 0, this);
+			}
 		}
-		back.updateSize();
 	}
 
 	@Override public void removeAll() {

--- a/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
+++ b/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
@@ -102,7 +102,7 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		assert yArg instanceof RTIntegerObject;
 		assert widthArg instanceof RTIntegerObject;
 		assert heightArg instanceof RTIntegerObject;
-		
+
 		final int x = (int)((RTIntegerObject)xArg).intValue();
 		final int y = (int)((RTIntegerObject)yArg).intValue();
 		final int width = (int)((RTIntegerObject)widthArg).intValue();
@@ -152,7 +152,7 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 			back.g.drawString(string, x, y);
 		}
 	}
-	
+
 	public void handleEventProgrammatically(final Event e) {
 		final RTType rTType = rTPanel_.rTType();
 		assert rTType instanceof RTClass;
@@ -164,12 +164,12 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 
 		pl.addFormalParameter(event);
 		pl.addFormalParameter(self);
-		
+
 		final RTMethod hE = rTType.lookupMethod("handleEvent", pl);
 		if (null != hE) {
 			final int preStackDepth = RunTimeEnvironment.runTimeEnvironment_.stackSize();
 			this.dispatchInterrupt(hE, e);
-			
+
 			// Get the return value from the user function telling whether they
 			// handled the interrupt or not. If not, we should handle it ourselves
 			// (if it's a keystroke event)
@@ -183,22 +183,22 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 			if ((oldEventArg instanceof RTObjectCommon) && ((RTObjectCommon)oldEventArg).rTType() instanceof RTEventClass == false) {
 				assert false;
 			}
-			
+
 			int postStackDepth = RunTimeEnvironment.runTimeEnvironment_.stackSize();
 
 			if (postStackDepth != preStackDepth) {
 				// assert postStackDepth == preStackDepth;
 				assert (postStackDepth > preStackDepth);
-				
+
 				// Dunno what's going on but just try to recover
 				while (postStackDepth > preStackDepth) {
 					RunTimeEnvironment.runTimeEnvironment_.popStack();
 					postStackDepth = RunTimeEnvironment.runTimeEnvironment_.stackSize();
 				}
-				
+
 				return;
 			}
-			
+
 			if (retval instanceof RTBooleanObject) {
 				final boolean interruptWasHandled = ((RTBooleanObject)retval).value();
 				if (interruptWasHandled == false) {
@@ -215,13 +215,13 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 			}
 		}
 	}
-	
+
 	protected void checkIOIntegration(final Event e) {
 		if (null != eventsAreBeingHijacked_) {
 			eventsAreBeingHijacked_.checkIOIntegration(e);
 		}
 	}
-	
+
 	private void dispatchInterrupt(final RTMethod method, final Event e) {
 		// Just do a method call into the user space
 		final RTCode halt = null;
@@ -237,12 +237,12 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		RunTimeEnvironment.runTimeEnvironment_.pushStack(event);
 		RunTimeEnvironment.runTimeEnvironment_.pushStack(retInst);
 		RunTimeEnvironment.runTimeEnvironment_.setFramePointer();
-		
+
 		final RTDynamicScope activationRecord = new RTDynamicScope(
 				method.name(),
 				RunTimeEnvironment.runTimeEnvironment_.currentDynamicScope(),
 				true);
-		
+
 		if (null != methodDecl) {
 			// Get formal parameter name that the user used for the "event" parameter
 			final MethodSignature signature = methodDecl.signature();
@@ -250,27 +250,27 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 			final Declaration eventParameter = formalParameters.parameterAtPosition(1);
 			assert eventParameter instanceof ObjectDeclaration;
 			final String eventName = eventParameter.name();
-			
+
 			activationRecord.addObjectDeclaration(eventName, rTType);
 			activationRecord.addObjectDeclaration("this", null);
 			activationRecord.setObject(eventName, event);
 			activationRecord.setObject("this", rTPanel_);
 			RunTimeEnvironment.runTimeEnvironment_.pushDynamicScope(activationRecord);
 			activationRecord.incrementReferenceCount();
-			
+
 			RTCode pc = method;
 			do {
 				pc = RunTimeEnvironment.runTimeEnvironment_.runner(pc);
 			} while (null != pc && pc instanceof RTHalt == false);
 		}
 	}
-	
+
 	// ------------------ Internal stuff ------------------------------
 
 	@Override public void actionPerformed(final ActionEvent event) {
 		assert false;
 	}
-	
+
 	@Override public synchronized boolean handleEvent(final Event e) {
 		// These constants need to be coordinated only with stuff in the
 		// setup and postSetupInitialization methods in PanelClass.java
@@ -278,12 +278,12 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 			--inInterrupt_;
 			return false;
 		}
-		
+
 		boolean retval = false;
-		
+
 		try {
 			int startingStackSize = 0;
-			
+
 			switch (e.id) {
 			  case Event.KEY_PRESS:
 			  case Event.KEY_RELEASE:
@@ -299,12 +299,12 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 				this.handleEventProgrammatically(e);
 
 				assert RunTimeEnvironment.runTimeEnvironment_.stackSize() <= startingStackSize;
-				
+
 				// Desperate attempt to fix up something that we don't know the reason for
 				while (RunTimeEnvironment.runTimeEnvironment_.stackSize() != startingStackSize) {
 					RunTimeEnvironment.runTimeEnvironment_.popStack();
 				}
-			
+
 				retval = true;
 				break;
 			  case Event.WINDOW_DESTROY:
@@ -346,7 +346,7 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		synchronized (this){
 			Buffer temp = back;
 			back = front;
-			front = back;
+			front = temp;
 		}
 		back.updateSize();
 	}
@@ -400,9 +400,9 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 	private volatile Buffer front = new Buffer();
 
 	private       RTObjectCommon rTPanel_;
-	
+
 	private       static volatile int inInterrupt_ = 0, inDrawing_ = 0;
-	
+
 	private static final long serialVersionUID = 238269472;
 	private               int referenceCount_ = 0;
 
@@ -447,6 +447,6 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 	@Override public void unenlistAsStagePropPlayerForContext(String stagePropName,
 			RTContextObject contextInstance) { assert false; }
 	@Override public String getText() { assert false; return null; }
-	
+
 	private GraphicsEventHandler eventsAreBeingHijacked_;
 }

--- a/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
+++ b/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
@@ -15,7 +15,6 @@ import info.fulloo.trygve.run_time.RTClass;
 import info.fulloo.trygve.run_time.RTClass.RTObjectClass.RTHalt;
 import info.fulloo.trygve.run_time.RTCode;
 import info.fulloo.trygve.run_time.RTColorObject;
-import info.fulloo.trygve.run_time.RTCookieObject;
 import info.fulloo.trygve.run_time.RTDynamicScope;
 import info.fulloo.trygve.run_time.RTEventObject;
 import info.fulloo.trygve.run_time.RTObjectCommon.RTBooleanObject;
@@ -34,9 +33,7 @@ import info.fulloo.trygve.semantic_analysis.StaticScope;
 import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.awt.geom.Ellipse2D;
 import java.util.Map;
-import java.util.Vector;
 
 // From DrawText.java
 
@@ -45,19 +42,11 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		rTPanel_ = rTPanel;
 	}
 
-	public void setBackground(final RTObject colorArg) {
+	public void setColor(final RTObject colorArg) {
 		assert colorArg instanceof RTColorObject;
 		final Color color = ((RTColorObject)colorArg).color();
 
 		if(back.g != null){
-			back.g.setColor(color);
-		}
-	}
-	public void setForeground(final RTObject colorArg) {
-		assert colorArg instanceof RTColorObject;
-		final Color color = ((RTColorObject)colorArg).color();
-
-		if(back.g != null) {
 			back.g.setColor(color);
 		}
 	}
@@ -132,13 +121,12 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int y = (int)((RTIntegerObject)yArg).intValue();
 		final int width = (int)((RTIntegerObject)widthArg).intValue();
 		final int height = (int)((RTIntegerObject)heightArg).intValue();
-		final Color currentColor = getForeground();
 
 		if(back.g != null){
 			back.g.fillOval(x, y, width, height);
 		}
 	}
-	public RTObject drawString(final RTObject xArg, final RTObject yArg, final RTObject stringArg) {
+	public void drawString(final RTObject xArg, final RTObject yArg, final RTObject stringArg) {
 		assert xArg instanceof RTIntegerObject;
 		assert yArg instanceof RTIntegerObject;
 		assert stringArg instanceof RTStringObject;
@@ -149,10 +137,6 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		if(back.g != null){
 			back.g.drawString(string, x, y);
 		}
-
-		final Color currentColor = getForeground();
-		final RTObject retval = this.addString(x, y, string, currentColor);
-		return retval;
 	}
 	
 	public void handleEventProgrammatically(final Event e) {
@@ -269,30 +253,6 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 	
 	// ------------------ Internal stuff ------------------------------
 
-	private static class StringRecord {
-		public StringRecord(final int x, final int y, final String string, final Color color) {
-			x_ = x;
-			y_ = y;
-			string_ = string;
-			color_ = color;
-			if (null == color_) {
-				color_ = Color.black;
-			}
-		}
-		
-		@Override public String toString() {
-			return string_;
-		}
-		
-		public int x() { return x_; }
-		public int y() { return y_; }
-		public Color color() { return color_; }
-		
-		private final int x_, y_;
-		private String string_;
-		private Color color_;
-	}
-	
 	@Override public void actionPerformed(final ActionEvent event) {
 		assert false;
 	}
@@ -380,22 +340,10 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 	@Override public void removeAll() {
 		super.removeAll();
 	}
-	
-	public void remove(final RTObject thingToRemoveRTObject) {
-		assert thingToRemoveRTObject instanceof RTCookieObject;
-		final Object thingToRemove = ((RTCookieObject)thingToRemoveRTObject).cookie();
-	}
-	
-	public synchronized RTObject addString(final int x, final int y, final String string, final Color color) {
-		final StringRecord stringRecord = new StringRecord(x, y, string, color);
-		final RTObject retval = new RTCookieObject(stringRecord);
-		return retval;
-	}
-	
+
 	public void setGraphicsEventHandler(final GraphicsEventHandler eventsAreBeingHijacked) {
 		eventsAreBeingHijacked_ = eventsAreBeingHijacked;
 	}
-
 
 	class Buffer {
 		Image image;

--- a/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
+++ b/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
@@ -152,6 +152,16 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 			back.g.drawString(string, x, y);
 		}
 	}
+	public Point measureString(final RTObject stringArg) {
+		assert stringArg instanceof RTStringObject;
+		final String string = ((RTStringObject)stringArg).stringValue();
+
+		if(candraw()){
+			final FontMetrics m = back.g.getFontMetrics();
+			return new Point(m.stringWidth(string), m.getHeight());
+		}
+		return new Point(string.length(), 10);
+	}
 
 	public void handleEventProgrammatically(final Event e) {
 		final RTType rTType = rTPanel_.rTType();

--- a/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
+++ b/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
@@ -42,13 +42,27 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		rTPanel_ = rTPanel;
 	}
 
+	public boolean candraw(){
+		if(back.g == null){
+			back.reset();
+		}
+		return back.g != null;
+	}
+
 	public void setColor(final RTObject colorArg) {
 		assert colorArg instanceof RTColorObject;
 		final Color color = ((RTColorObject)colorArg).color();
 
-		if(back.g != null){
+		if(candraw()){
 			back.g.setColor(color);
 		}
+	}
+
+	public Color getColor() {
+		if(candraw()) {
+			return back.g.getColor();
+		}
+		return Color.white;
 	}
 	public void drawLine(final RTObject fromXArg, final RTObject fromYArg, final RTObject toXArg, final RTObject toYArg) {
 		assert fromXArg instanceof RTIntegerObject;
@@ -60,12 +74,12 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int toX = (int)((RTIntegerObject)toXArg).intValue();
 		final int toY = (int)((RTIntegerObject)toYArg).intValue();
 
-		if(back.g != null) {
+		if(candraw()){
 			back.g.drawLine(fromX, fromY, toX, toY);
 		}
 	}
 	public void clear(){
-		if(back.g != null){
+		if(candraw()){
 			back.g.clearRect(0, 0, back.width, back.height);
 		}
 	}
@@ -79,7 +93,7 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int width = (int)((RTIntegerObject)widthArg).intValue();
 		final int height = (int)((RTIntegerObject)heightArg).intValue();
 
-		if(back.g != null){
+		if(candraw()){
 			back.g.drawRect(fromX, fromY, width, height);
 		}
 	}
@@ -94,7 +108,7 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int width = (int)((RTIntegerObject)widthArg).intValue();
 		final int height = (int)((RTIntegerObject)heightArg).intValue();
 
-		if(back.g != null){
+		if(candraw()){
 			back.g.fillRect(x, y, width, height);
 		}
 	}
@@ -108,7 +122,7 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int width = (int)((RTIntegerObject)widthArg).intValue();
 		final int height = (int)((RTIntegerObject)heightArg).intValue();
 
-		if(back.g != null){
+		if(candraw()){
 			back.g.drawOval(x, y, width, height);
 		}
 	}
@@ -122,7 +136,7 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int width = (int)((RTIntegerObject)widthArg).intValue();
 		final int height = (int)((RTIntegerObject)heightArg).intValue();
 
-		if(back.g != null){
+		if(candraw()){
 			back.g.fillOval(x, y, width, height);
 		}
 	}
@@ -134,7 +148,7 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int y = (int)((RTIntegerObject)yArg).intValue();
 		final String string = ((RTStringObject)stringArg).stringValue();
 
-		if(back.g != null){
+		if(candraw()){
 			back.g.drawString(string, x, y);
 		}
 	}
@@ -370,7 +384,8 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 			System.gc();
 
 			if(width == 0 || height == 0){
-				return;
+				width = 640;
+				height = 480;
 			}
 
 			image = createImage(width, height);

--- a/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
+++ b/src/main/java/info/fulloo/trygve/graphics/GraphicsPanel.java
@@ -43,17 +43,23 @@ import java.util.Vector;
 public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 	public GraphicsPanel(final RTObjectCommon rTPanel) {
 		rTPanel_ = rTPanel;
-		makeVectors();
 	}
+
 	public void setBackground(final RTObject colorArg) {
 		assert colorArg instanceof RTColorObject;
 		final Color color = ((RTColorObject)colorArg).color();
-		this.setBackground(color);
+
+		if(back.g != null){
+			back.g.setColor(color);
+		}
 	}
 	public void setForeground(final RTObject colorArg) {
 		assert colorArg instanceof RTColorObject;
 		final Color color = ((RTColorObject)colorArg).color();
-		this.setForeground(color);
+
+		if(back.g != null) {
+			back.g.setColor(color);
+		}
 	}
 	public void drawLine(final RTObject fromXArg, final RTObject fromYArg, final RTObject toXArg, final RTObject toYArg) {
 		assert fromXArg instanceof RTIntegerObject;
@@ -64,9 +70,15 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int fromY = (int)((RTIntegerObject)fromYArg).intValue();
 		final int toX = (int)((RTIntegerObject)toXArg).intValue();
 		final int toY = (int)((RTIntegerObject)toYArg).intValue();
-		final Rectangle newRect = new Rectangle(fromX, fromY, Math.abs(toX-fromX), Math.abs(toY-fromY));
-		final Color currentColor = getForeground();
-		this.addLine(newRect, currentColor);
+
+		if(back.g != null) {
+			back.g.drawLine(fromX, fromY, toX, toY);
+		}
+	}
+	public void clear(){
+		if(back.g != null){
+			back.g.clearRect(0, 0, back.width, back.height);
+		}
 	}
 	public void drawRect(final RTObject fromXArg, final RTObject fromYArg, final RTObject widthArg, final RTObject heightArg) {
 		assert fromXArg instanceof RTIntegerObject;
@@ -77,9 +89,10 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int fromY = (int)((RTIntegerObject)fromYArg).intValue();
 		final int width = (int)((RTIntegerObject)widthArg).intValue();
 		final int height = (int)((RTIntegerObject)heightArg).intValue();
-		final Rectangle newRect = new Rectangle(fromX, fromY, width, height);
-		final Color currentColor = getForeground();
-		this.addRectangle(newRect, currentColor);
+
+		if(back.g != null){
+			back.g.drawRect(fromX, fromY, width, height);
+		}
 	}
 	public void fillRect(final RTObject xArg, final RTObject yArg, final RTObject widthArg, final RTObject heightArg) {
 		assert xArg instanceof RTIntegerObject;
@@ -91,8 +104,10 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int y = (int)((RTIntegerObject)yArg).intValue();
 		final int width = (int)((RTIntegerObject)widthArg).intValue();
 		final int height = (int)((RTIntegerObject)heightArg).intValue();
-		final Color currentColor = getForeground();
-		this.addFilledRectangle(x, y, width, height, currentColor);
+
+		if(back.g != null){
+			back.g.fillRect(x, y, width, height);
+		}
 	}
 	public void drawOval(final RTObject xArg, final RTObject yArg, final RTObject widthArg, final RTObject heightArg) {
 		assert xArg instanceof RTIntegerObject;
@@ -103,8 +118,10 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int y = (int)((RTIntegerObject)yArg).intValue();
 		final int width = (int)((RTIntegerObject)widthArg).intValue();
 		final int height = (int)((RTIntegerObject)heightArg).intValue();
-		final Color currentColor = getForeground();
-		this.addOval(x, y, width, height, currentColor);
+
+		if(back.g != null){
+			back.g.drawOval(x, y, width, height);
+		}
 	}
 	public void fillOval(final RTObject xArg, final RTObject yArg, final RTObject widthArg, final RTObject heightArg) {
 		assert xArg instanceof RTIntegerObject;
@@ -116,7 +133,10 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int width = (int)((RTIntegerObject)widthArg).intValue();
 		final int height = (int)((RTIntegerObject)heightArg).intValue();
 		final Color currentColor = getForeground();
-		this.addFilledOval(x, y, width, height, currentColor);
+
+		if(back.g != null){
+			back.g.fillOval(x, y, width, height);
+		}
 	}
 	public RTObject drawString(final RTObject xArg, final RTObject yArg, final RTObject stringArg) {
 		assert xArg instanceof RTIntegerObject;
@@ -125,6 +145,11 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		final int x = (int)((RTIntegerObject)xArg).intValue();
 		final int y = (int)((RTIntegerObject)yArg).intValue();
 		final String string = ((RTStringObject)stringArg).stringValue();
+
+		if(back.g != null){
+			back.g.drawString(string, x, y);
+		}
+
 		final Color currentColor = getForeground();
 		final RTObject retval = this.addString(x, y, string, currentColor);
 		return retval;
@@ -243,27 +268,7 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 	}
 	
 	// ------------------ Internal stuff ------------------------------
-	
-	private void makeVectors() {
-		rectangles_ = new Vector<Rectangle>();
-		rectColors_ = new Vector<Color>();
-		
-		filledRectangles_ = new Vector<Rectangle>();
-		filledRectangleColors_ = new Vector<Color>();
-		
-		// A line is a funny kind of Rectangle (Javathink)
-		lines_ = new Vector<Rectangle>();
-		lineColors_ = new Vector<Color>();
-		
-		ellipses_ = new Vector<Ellipse2D>();
-		ellipseColors_ = new Vector<Color>();
-		
-		filledEllipses_ = new Vector<Ellipse2D>();
-		filledEllipseColors_ = new Vector<Color>();
-		
-		strings_ = new Vector<StringRecord>();
-	}
-	
+
 	private static class StringRecord {
 		public StringRecord(final int x, final int y, final String string, final Color color) {
 			x_ = x;
@@ -318,12 +323,7 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 			  case Event.MOUSE_UP:
 				startingStackSize = RunTimeEnvironment.runTimeEnvironment_.stackSize();
 				this.handleEventProgrammatically(e);
-				// final Graphics g = this.getGraphics();
-				// if (null != g) {
-				// 	paint(g);
-				// 	repaint();
-				// }
-				
+
 				assert RunTimeEnvironment.runTimeEnvironment_.stackSize() <= startingStackSize;
 				
 				// Desperate attempt to fix up something that we don't know the reason for
@@ -352,191 +352,42 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 		}
 		return retval;
 	}
-	
-	private synchronized void drawEllipses(final Graphics g) {
-		try {
-			/* draw the current ellipses */
-			g.setColor(getForeground());
-			g.setPaintMode();
-			for (int i = 0; i < ellipses_.size(); i++) {
-			    final Ellipse2D p = ellipses_.elementAt(i);
-			    g.setColor((Color)ellipseColors_.elementAt(i));
-			    g.drawOval((int)p.getX(), (int)p.getY(), (int)p.getWidth(), (int)p.getHeight());
+
+	@Override public void update(Graphics g){
+		paint(g);
+	}
+	@Override public void paint(final Graphics g) {
+		synchronized (this){
+			if(front == null || front.g == null){
+				front.reset();
 			}
-		} catch (ArrayIndexOutOfBoundsException exception) {
-			;
+
+			if(front != null && front.g != null){
+				g.drawImage(front.image, 0, 0, this);
+			}
 		}
 	}
-	private synchronized void drawFilledEllipses(final Graphics g) {
-		/* same, only filled ellipses */
-		try {
-			for (int i = 0; i < filledEllipses_.size(); i++) {
-				final Ellipse2D p = filledEllipses_.elementAt(i);
-				g.setColor((Color)filledEllipseColors_.elementAt(i));
-				g.fillOval((int)p.getX(), (int)p.getY(), (int)p.getWidth(), (int)p.getHeight());
-			}
-		} catch (ArrayIndexOutOfBoundsException exception) {
-			;
+
+	public void flipBuffers(){
+		synchronized (this){
+			Buffer temp = back;
+			back = front;
+			front = back;
 		}
+		back.updateSize();
 	}
-	
-	@Override synchronized public void paint(final Graphics g) {
-		if (inDrawing_++ > 0) {
-			--inDrawing_;
-			return;
-		}
-		
-		/* draw the current rectangles */
-		g.setColor(getForeground());
-		g.setPaintMode();
-		
-		// Copies, just in case we get interrupted
-		@SuppressWarnings("unchecked")
-		final Vector<Rectangle> rectanglesCopy = (Vector<Rectangle>) rectangles_.clone();
-		
-		@SuppressWarnings("unchecked")
-		final Vector<Color> rectColorsCopy = (Vector<Color>) rectColors_.clone();
-		
-		try {
-			for (int i = 0; i < rectanglesCopy.size(); i++) {
-			    final Rectangle p = rectanglesCopy.elementAt(i);
-			    g.setColor((Color)rectColorsCopy.elementAt(i));
-			    if (p.width != -1) {
-			    	g.drawRect(p.x, p.y, p.width, p.height);
-			    } else {
-			    	g.drawLine(p.x, p.y, p.width, p.height);
-			    }
-			}
-		} catch (final ArrayIndexOutOfBoundsException exception) {
-			;
-		}
-		
-		// filled rectangles
-		@SuppressWarnings("unchecked")
-		final Vector<Rectangle> filledRectanglesCopy = (Vector<Rectangle>) filledRectangles_.clone();
-		
-		@SuppressWarnings("unchecked")
-		final Vector<Color> filledRectColorsCopy = (Vector<Color>) filledRectangleColors_.clone();
-		
-		try {
-			for (int i = 0; i < filledRectanglesCopy.size(); i++) {
-			    final Rectangle p = filledRectanglesCopy.elementAt(i);
-			    g.setColor((Color)filledRectColorsCopy.elementAt(i));
-			    if (p.width != -1) {
-			    	g.fillRect(p.x, p.y, p.width, p.height);
-			    } else {
-			    	// ???
-			    	g.drawLine(p.x, p.y, p.width, p.height);
-			    }
-			}
-		} catch (final ArrayIndexOutOfBoundsException exception) {
-			;
-		}
-		
-		/* draw the current lines */
-		g.setColor(getForeground());
-		g.setPaintMode();
-		for (int i = 0; i < lines_.size(); i++) {
-		    final Rectangle p = lines_.elementAt(i);
-		    g.setColor((Color)lineColors_.elementAt(i));
-		    g.drawLine(p.x, p.y, p.x+p.width, p.y+p.height);
-		}
-		
-		drawEllipses(g);
-		drawFilledEllipses(g);
-		
-		/* draw the current texts */
-		g.setColor(getForeground());
-		g.setPaintMode();
-		for (int i = 0; i < strings_.size(); i++) {
-		    final StringRecord p = strings_.elementAt(i);
-		    g.setColor(p.color());
-		    g.drawString(p.toString(), p.x(), p.y());
-		}
-		
-		inDrawing_ = 0;
-	}
-	
+
 	@Override public void removeAll() {
-		makeVectors();
 		super.removeAll();
 	}
 	
 	public void remove(final RTObject thingToRemoveRTObject) {
 		assert thingToRemoveRTObject instanceof RTCookieObject;
 		final Object thingToRemove = ((RTCookieObject)thingToRemoveRTObject).cookie();
-
-		boolean removed = false;
-		for (int i = 0; i < strings_.size(); i++) {
-			if (strings_.get(i) == thingToRemove) {
-				strings_.remove(i);
-				removed = true;
-				break;
-			}
-		}
-		if (removed == false) {
-			for (int i = 0; i < ellipses_.size(); i++) {
-				if (ellipses_.get(i) == thingToRemove) {
-					ellipses_.remove(i);
-					ellipseColors_.remove(i);
-					removed = true;
-					break;
-				}
-			}
-			if (removed == false) {
-				for (int i = 0; i < rectangles_.size(); i++) {
-					if (rectangles_.get(i) == thingToRemove) {
-						rectangles_.remove(i);
-						rectColors_.remove(i);
-						removed = true;
-						break;
-					}
-				}
-				if (removed == false) {
-					for (int i = 0; i < lines_.size(); i++) {
-						if (lines_.get(i) == thingToRemove) {
-							lines_.remove(i);
-							lineColors_.remove(i);
-							removed = true;
-							break;
-						}
-					}
-				}
-			}
-		}
-	}
-	
-	public synchronized void addRectangle(final Rectangle rect, final Color color) {
-		rectangles_.addElement(rect);
-		rectColors_.addElement(color);
-	}
-	
-	public synchronized void addFilledRectangle(final int x, final int y, final int width, final int height, final Color color) {
-		final Rectangle rect = new Rectangle(x, y, width, height);
-		filledRectangles_.addElement(rect);
-		filledRectangleColors_.addElement(color);
-	}
-	
-	public synchronized void addLine(final Rectangle line, final Color color) {
-		lines_.addElement(line);
-		lineColors_.addElement(color);
-	}
-	
-	public synchronized void addOval(final int x, final int y, final int width, final int height, final Color color) {
-		final Ellipse2D ellipse = new Ellipse2D.Float(x, y, width, height);
-		ellipses_.addElement(ellipse);
-		ellipseColors_.addElement(color);
-	}
-	
-	public synchronized void addFilledOval(final int x, final int y, final int width, final int height, final Color color) {
-		final Ellipse2D ellipse = new Ellipse2D.Float(x, y, width, height);
-		filledEllipses_.addElement(ellipse);
-		filledEllipseColors_.addElement(color);
 	}
 	
 	public synchronized RTObject addString(final int x, final int y, final String string, final Color color) {
 		final StringRecord stringRecord = new StringRecord(x, y, string, color);
-		strings_.addElement(stringRecord);
 		final RTObject retval = new RTCookieObject(stringRecord);
 		return retval;
 	}
@@ -544,23 +395,44 @@ public class GraphicsPanel extends Panel implements ActionListener, RTObject {
 	public void setGraphicsEventHandler(final GraphicsEventHandler eventsAreBeingHijacked) {
 		eventsAreBeingHijacked_ = eventsAreBeingHijacked;
 	}
-	
-	private       volatile Vector<Rectangle> rectangles_;
-	private       volatile Vector<Color> rectColors_;
-	
-	private       volatile Vector<Rectangle> filledRectangles_;
-	private       volatile Vector<Color> filledRectangleColors_;
-	
-	private       volatile Vector<Rectangle> lines_;
-	private       volatile Vector<Color> lineColors_;
-	
-	private       volatile Vector<Ellipse2D> ellipses_;
-	private       volatile Vector<Color> ellipseColors_;
-	
-	private       volatile Vector<Ellipse2D> filledEllipses_;
-	private       volatile Vector<Color> filledEllipseColors_;
-	
-	private       volatile Vector<StringRecord> strings_;
+
+
+	class Buffer {
+		Image image;
+		Graphics g;
+		int width, height;
+
+		public void updateSize(){
+			if(height != getSize().height || width != getSize().width){
+				reset();
+			}
+		}
+
+		public void reset(){
+			height = getSize().height;
+			width = getSize().width;
+			if(g != null){
+				g.dispose();
+				g = null;
+			}
+			if(image != null){
+				image.flush();
+				image = null;
+			}
+			System.gc();
+
+			if(width == 0 || height == 0){
+				return;
+			}
+
+			image = createImage(width, height);
+			g = image.getGraphics();
+		}
+	}
+
+	private volatile Buffer back = new Buffer();
+	private volatile Buffer front = new Buffer();
+
 	private       RTObjectCommon rTPanel_;
 	
 	private       static volatile int inInterrupt_ = 0, inDrawing_ = 0;

--- a/tests/mouse_info_test.k
+++ b/tests/mouse_info_test.k
@@ -3,7 +3,7 @@
 class MyPanel extends Panel {
    int XSIZE = 1000;
    int YSIZE = 600;
-   
+
    public int xsize() const { return XSIZE }
    public int ysize() const { return YSIZE }
 
@@ -18,7 +18,7 @@ class MyPanel extends Panel {
    }
 
    public Frame frame() { return frame_ }
- 
+
    private Frame frame_
 }
 
@@ -33,7 +33,7 @@ context Arena {
    }
    public void run() {
       do {
-         THE_PANEL.clearObjects();
+         THE_PANEL.clear();
          System.err.println(MouseInfo.getPointerInfo().getLocation().x)
          Thread.sleep(20)
       } while (true)
@@ -43,8 +43,6 @@ context Arena {
    role THE_PANEL {
       public int maxX() const { return xsize() }
       public int maxY() const { return ysize() }
-      public void setColor(Color c) { setForeground(c) }
-      public void clearObjects() { removeAll() }
       public void clear() {
          setColor(new Color(227, 221, 240));
          fillRect(0, 0, maxX()-1, maxY()-1)
@@ -55,8 +53,7 @@ context Arena {
       void fillRect(int x, int y, int h, int w);
       int xsize() const;
       int ysize() const;
-      void removeAll();
-      void setForeground(Color color)
+      void setColor(Color color)
    }
 }
 

--- a/tests/trygve_pong.k
+++ b/tests/trygve_pong.k
@@ -51,20 +51,19 @@ context Arena implements EventHandler {
 		BALL = new BallObject(50, 50);
 		PADDLE = new Point(450, 560);
 		panel.setEventHandler(this)
-	} 
+	}
 	private boolean handleEvent(Event e) {
 		if (e.id == Event.MOUSE_MOVE) {PADDLE.moveTo(new Point(e.x, e.y))}
 		return true
 	}
 	public void run() {
 		do {
-			THE_PANEL.clearObjects();
-			PADDLE.erase();
+			THE_PANEL.clear();
 			PADDLE.draw();
-			BALL.erase()
 			BALL.velocityAdjust();
 			BALL.draw();
 			BALL.step();
+			THE_PANEL.flush();
 			Thread.sleep(20)
 		}while (true)
 	}
@@ -74,8 +73,7 @@ context Arena implements EventHandler {
 			public void drawPADDLE(int xs, int ys, int h, int w) { drawRect(xs, ys, h, w) }
 			public int maxX() const { return xsize() }
 			public int maxY() const { return ysize() }
-			public void setColor(Color c) { setForeground(c) }
-			public void clearObjects() { removeAll() }
+			public void flush(){ repaint() }
 			public void clear() {
 			setColor(new Color(227, 221, 240));
 			fillRect(0, 0, maxX()-1, maxY()-1)
@@ -86,8 +84,8 @@ context Arena implements EventHandler {
 		void fillRect(int x, int y, int h, int w);
 		int xsize() const;
 		int ysize() const;
-		void removeAll();
-		void setForeground(Color color)
+		void setColor(Color color);
+		void repaint();
 	}
 	role PADDLE {
 			public int thickness() const { return 10 }


### PR DESCRIPTION
These changes remove the Panel flickering, however some of the examples don't work quite right. (e.g. the borrow_library_panel examples). I'm not sure how to fix them. They looked broken before.

Also I made changes to the Panel API to make it reflect more how it does things internally, specifically:
- Removed `Panel.getForeground`, `Panel.setForeground`, `Panel.getBackground`, `Panel.setBackground` and replaced them with `Panel.getColor` and `Panel.setColor`.
- Removed `Panel.removeAll`, `Panel.remove` since they don't do anything anymore, things are rendered directly to a backbuffer.
- Similarly `Panel.drawString` doesn't return anything, because everything is rasterized immediately.
- Added `Panel.measureString` to make text positioning easier.

Calling `Panel.repaint` is now required to swap the front and backbuffer and `Panel.clear` is necessary to clear the previous image from backbuffer.
