### PR TITLE
Small fix Math.round method to accept argument of type double 

### DIFF
--- a/src/main/java/info/fulloo/trygve/add_ons/MathClass.java
+++ b/src/main/java/info/fulloo/trygve/add_ons/MathClass.java
@@ -97,7 +97,7 @@ public final class MathClass {
 			addSimpleStaticMethodDeclaration("sqrt", asList("x"), asList(doubleType), doubleType);
 			addSimpleStaticMethodDeclaration("abs", asList("x"), asList(doubleType), doubleType);
 			addSimpleStaticMethodDeclaration("abs", asList("x"), asList(intType), intType);
-			addSimpleStaticMethodDeclaration("round", asList("x"), asList(intType), intType);
+			addSimpleStaticMethodDeclaration("round", asList("x"), asList(doubleType), intType);
 			addSimpleStaticMethodDeclaration("max", asList("x", "y"), asList(doubleType, doubleType), doubleType);
 			addSimpleStaticMethodDeclaration("max", asList("x", "y"), asList(intType, intType), intType);
 			addSimpleStaticMethodDeclaration("min", asList("x", "y"), asList(doubleType, doubleType), doubleType);

--- a/tests/math_round.k
+++ b/tests/math_round.k
@@ -1,0 +1,17 @@
+{
+    double n1 = 2.34
+    int i = Math.round(n1)
+    System.out.println(i)
+
+    double n2 = 2.51
+    double d = Math.round(n2)
+    System.out.println(d)
+}
+
+/* GOLD:
+line 7: WARNING: Substituting double object for `Math.round()' in assignment to `d'.
+1 warning, 0 errors.
+___________________________________________________________
+2
+3.0
+*/


### PR DESCRIPTION
A small fix for issue #118 that allows the method round of class Math accepts double as stated in the user manual of trygve.