### PR TITLE
Reduced size of distribution zip.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,11 @@ repositories {
 
 dependencies {
     antlr "org.antlr:antlr4:4.10"
+    implementation "org.antlr:antlr4-runtime:4.10"
+}
+
+configurations.implementation {
+    exclude group: "org.antlr", module: "antlr4"
 }
 
 generateGrammarSource {
@@ -23,12 +28,6 @@ application {
 
 }
 
-build {
-    configure {
-        dependsOn generateGrammarSource
-    }
-}
-
 // make it executable
 jar {
     manifest {
@@ -36,6 +35,13 @@ jar {
             'Main-Class': "info.fulloo.trygve.editor.Main"
         )
     }
+
+    /*
+    // Make a fat jar
+    from {
+        configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    }
+    */
 }
 
 // default arguments for "gradlew run"
@@ -53,11 +59,4 @@ distZip {
     }
 }
 
-distTar {
-    into(project.name) {
-        from '.'
-        include 'examples/*'
-        include 'tests/*'
-        include 'LICENSE'
-    }
-}
+distTar.enabled = false


### PR DESCRIPTION
Only `antlr-runtime` is needed at runtime, so the size of the zip decreased 10 times when excluding the `antlr` dependencies from the distribution.

Also removed tar file to keep things simple, any system can handle zip.