### PR TITLE
Only including antlr runtime in distribution.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,12 @@ repositories {
 
 dependencies {
     antlr "org.antlr:antlr4:4.10"
+    implementation "org.antlr:antlr4-runtime:4.10"
+}
+
+// exclude antlr, we only need its runtime in the dist.
+configurations.implementation {
+    exclude group: "org.antlr", module: "antlr4"
 }
 
 generateGrammarSource {
@@ -36,6 +42,11 @@ jar {
             'Main-Class': "info.fulloo.trygve.editor.Main"
         )
     }
+
+    // If needed, a fat jar (all dependencies in one file) can be made like this:
+    // from {
+    //    configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
+    //}
 }
 
 // default arguments for "gradlew run"


### PR DESCRIPTION
Since only the antlr runtime is required when running trygve, the distribution files (zip, tar) can be trimmed of unnecessary dependencies, putting them back close to their original size before the 2022 update.